### PR TITLE
fix(theme): update storefront-ui dependency

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@nuxtjs/pwa": "^3.3.5",
     "@nuxtjs/style-resources": "^1.2.1",
-    "@storefront-ui/vue": "^0.10.8",
+    "@storefront-ui/vue": ">=0.10.8 <0.10.71 || ^0.10.72",
     "@vue-storefront/core": "^2.3.4",
     "@vue-storefront/magento": "1.0.0-rc.2",
     "@vue-storefront/middleware": "^2.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3549,7 +3549,7 @@
   resolved "https://registry.yarnpkg.com/@storefront-ui/shared/-/shared-0.10.8.tgz#1717f528a073dcebbd6115f587c3cf57a94ee86a"
   integrity sha512-lRVqxs5QAOtXV129uNDSn0BYvjix0VXNZu2ChnQAu8jNKC/Q10cN1XrDiOEiL8hDpx7py+6DUka1WZ5K8dn+jQ==
 
-"@storefront-ui/vue@^0.10.8":
+"@storefront-ui/vue@>=0.10.8 <0.10.71 || ^0.10.72":
   version "0.10.8"
   resolved "https://registry.yarnpkg.com/@storefront-ui/vue/-/vue-0.10.8.tgz#9d3e999a4beb2188cca397dcb7cc7b3d5d9a6207"
   integrity sha512-+ePyaXITmGxWfDs4capCoTQoq76a38Q4UA9PEYgcBiCPeSOBXtAQ6NGOKooTK27y4m+2NLOyeh+kdsPSXlFVYg==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Just simple fix for storefront-ui version in package.json
- Skips version 0.10.71
- Does not require updates in feature, but could be done if guys from storefront-ui will fix the issue like suggested: https://github.com/vuestorefront/storefront-ui/issues/1952#issuecomment-898865188

## Related Issue
https://github.com/vuestorefront/magento2/issues/138

