### PR TITLE
fix: add shipping provider to basket

### DIFF
--- a/packages/api-client/src/api/setShippingMethodsOnCart/setShippingMethodsOnCart.ts
+++ b/packages/api-client/src/api/setShippingMethodsOnCart/setShippingMethodsOnCart.ts
@@ -1,21 +1,12 @@
 import gql from 'graphql-tag';
+import CompleteCartData from '../../fragments/completeCartFragment';
 
 export default gql`
+  ${CompleteCartData}
 mutation setShippingMethodsOnCart($input: SetShippingMethodsOnCartInput) {
   setShippingMethodsOnCart(input: $input) {
     cart {
-      shipping_addresses {
-        selected_shipping_method {
-          carrier_code
-          carrier_title
-          method_code
-          method_title
-          amount {
-            value
-            currency
-          }
-        }
-      }
+      ...CompleteCartData
     }
   }
 }`;

--- a/packages/composables/src/composables/useShippingProvider/index.ts
+++ b/packages/composables/src/composables/useShippingProvider/index.ts
@@ -39,10 +39,13 @@ const factoryParams: UseShippingProviderParams<any, any> = {
     };
 
     const { data } = await context.$magento.api.setShippingMethodsOnCart(shippingMethodParams);
+    const { cart } = data
+      .setShippingMethodsOnCart;
 
-    return data
-      .setShippingMethodsOnCart
-      .cart
+    console.log('Shipping provider save', data);
+    context.cart.setCart(cart);
+
+    return cart
       .shipping_addresses[0]
       .selected_shipping_method;
   },

--- a/packages/composables/src/composables/useShippingProvider/index.ts
+++ b/packages/composables/src/composables/useShippingProvider/index.ts
@@ -42,7 +42,6 @@ const factoryParams: UseShippingProviderParams<any, any> = {
     const { cart } = data
       .setShippingMethodsOnCart;
 
-    console.log('Shipping provider save', data);
     context.cart.setCart(cart);
 
     return cart


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shipping data is loaded from cart, so in order to display it right we load cart from M2 in setShippingMethodsOnCart same as done for other cart modifications, like removeItemFromCart, etc. 

## Related Issue
https://github.com/vuestorefront/magento2/issues/144

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Proceed to checkout and select shipping method
2. Check shipping provider and other cart data

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
