### PR TITLE
fix: set cart id for logged in customer

### DIFF
--- a/packages/composables/src/composables/useCart/index.ts
+++ b/packages/composables/src/composables/useCart/index.ts
@@ -66,6 +66,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     if (customerToken) {
       try {
         const result = await context.$magento.api.customerCart();
+        apiState.setCartId(result.data.customerCart.id);
 
         return result.data.customerCart as unknown as Cart;
       } catch {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If customer was logged in and useBasket.load was executed, no cart_id was stored to apiState which caused infinite loop on add to basket. Fixed. 

## Related Issue
https://github.com/vuestorefront/magento2/issues/166

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
