### PR TITLE
refactor(composables): update `load` method of `useCart` composable

### DIFF
--- a/packages/composables/src/composables/useCart/index.ts
+++ b/packages/composables/src/composables/useCart/index.ts
@@ -17,18 +17,23 @@ import {
 } from '@vue-storefront/magento-api';
 
 const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
-  load: async (context: Context) => {
+  load: async (context: Context, params: {
+    customQuery?: any;
+  }) => {
     const apiState = context.$magento.config.state;
     Logger.debug('[Magento Storefront]: Loading Cart');
-    const customerToken = apiState.getCustomerToken();
 
-    const createNewCart = async (): Promise<string> => {
+    const customerToken = apiState.getCustomerToken();
+    const virtual = !params.customQuery?.real;
+
+    const createVirtualCart = () => (null as Cart);
+
+    const createRealCart = async (): Promise<string> => {
       Logger.debug('[Magento Storefront]: useCart.load.createNewCart');
 
       apiState.setCartId();
 
       const { data } = await context.$magento.api.createEmptyCart();
-
       Logger.debug('[Result]:', { data });
 
       apiState.setCartId(data.createEmptyCart);
@@ -36,35 +41,29 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
       return data.createEmptyCart;
     };
 
-    const getCartData = async (id?: string) => {
-      const fetchData = async (cartId = id) => {
+    const getCartData = async (id: string) => {
+      Logger.debug('[Magento Storefront]: useCart.load.getCartData ID->', id);
+
+      const cartResponse = await context.$magento.api.cart(id);
+      Logger.debug('[Result]:', { data: cartResponse });
+
+      return cartResponse.data.cart as unknown as Cart;
+    };
+
+    const getCart = async (virtualCart: boolean, cartId?: string) => {
+      if (!cartId) {
+        if (virtualCart) {
+          return createVirtualCart();
+        }
+
+        cartId = await createRealCart();
         apiState.setCartId(cartId);
-        const cartResponse = await context.$magento.api.cart(cartId);
-
-        Logger.debug('[Result]:', { data: cartResponse });
-
-        return cartResponse.data.cart as unknown as Cart;
-      };
-
-      try {
-        Logger.debug('[Magento Storefront]: useCart.load.getCartData ID->', id);
-
-        return await fetchData();
-      } catch {
-        apiState.setCartId();
-
-        const cartId = await createNewCart();
-
-        return await fetchData(cartId);
       }
+
+      return getCartData(cartId);
     };
 
-    const generateCart = async (id?: string) => {
-      const cartId = await createNewCart();
-
-      return getCartData(id || apiState.getCartId() || cartId);
-    };
-
+    // Try to load cart for existing customer, clean customer token if not possible
     if (customerToken) {
       try {
         const result = await context.$magento.api.customerCart();
@@ -73,23 +72,19 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
         return result.data.customerCart as unknown as Cart;
       } catch {
         apiState.setCustomerToken();
-
-        return await generateCart();
       }
     }
-
-    const cartId = apiState.getCartId();
 
     try {
-      if (!cartId) {
-        return await generateCart();
-      }
-
-      return await getCartData(cartId);
+      // If it's not existing customer check if cart id is set and try to load it
+      const cartId = apiState.getCartId();
+      return await getCart(virtual, cartId);
     } catch {
-      return generateCart();
+      apiState.setCartId();
+      return await getCart(virtual);
     }
   },
+
   addItem: async (context: Context, {
     product,
     quantity,
@@ -100,9 +95,12 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
 
     const apiState = context.$magento.config.state;
     let currentCartId = apiState.getCartId();
-
     if (!currentCartId) {
-      await factoryParams.load(context, {});
+      await factoryParams.load(context, {
+        customQuery: {
+          real: true,
+        },
+      });
 
       currentCartId = apiState.getCartId();
     }
@@ -244,13 +242,22 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
       ],
     };
 
-    const { data } = await context.$magento.api.updateCartItems(updateCartParams);
+    try {
+      const { data } = await context.$magento.api.updateCartItems(updateCartParams);
 
-    Logger.debug('[Result]:', { data });
+      Logger.debug('[Result]:', { data });
 
-    return data
-      .updateCartItems
-      .cart as unknown as Cart;
+      return data
+        .updateCartItems
+        .cart as unknown as Cart;
+    } catch {
+      // If we can't change quantity, the card could be expired on Magento side, try to reload
+      return await factoryParams.load(context, {
+        customQuery: {
+          real: true,
+        },
+      });
+    }
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   clear: (context: Context, _params = null) => {
@@ -298,9 +305,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
       currentCart,
       product,
     },
-  ) => !!currentCart
-    .items
-    .find((cartItem) => cartItem.product.uid === product.uid),
+  ) => !!currentCart?.items.find((cartItem) => cartItem.product.uid === product.uid),
 };
 
 export default useCartFactory<Cart, CartItem, Product>(factoryParams);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

### :rocket:  Features
`composable`
- Do not create empty cart on Magento2 side if no actions are done with basket. Now no `createEmptyCart` mutation is executed if customer just browse the shop and does not interacts with basket.

### 💅 Refactors
`composable`
- Simplify and clean up basket load process for useCart composable
- Try to reload basket if it's expired on Magento2 side and actions for it are called (increase/decrease quantity, remove item, etc), clean basket if reload not possible

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

- https://github.com/vuestorefront/magento2/issues/147
- https://github.com/vuestorefront/magento2/issues/153


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### Open frontend with clean session 
- No cart record created on Magento2 DB side
- After adding product to basket cart record is created on Magento2 DB side
- All operations with cart work

### Open frontend with existing session
- Basket is loaded correctly

### Open frontend with clean session and log in with existing customer
- Customer basket is loaded from Magento2 DB

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
