### PR TITLE
feat(theme): #158 add cart coupon code input

### DIFF
--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -96,17 +96,22 @@
                 :key="`${cartGetters.getItemSku(product)}-${Math.random()}`"
                 :image="cartGetters.getItemImage(product)"
                 :title="cartGetters.getItemName(product)"
-                :regular-price="$n(cartGetters.getItemPrice(product).regular, 'currency')"
-                :special-price="cartGetters.productHasSpecialPrice(product)
-                  ? getItemPrice(product).special && $n(cartGetters.getItemPrice(product).special, 'currency')
-                  : ''"
+                :regular-price="
+                  $n(cartGetters.getItemPrice(product).regular, 'currency')
+                "
+                :special-price="
+                  cartGetters.productHasSpecialPrice(product)
+                    ? getItemPrice(product).special &&
+                      $n(cartGetters.getItemPrice(product).special, 'currency')
+                    : ''
+                "
                 :stock="99999"
                 :qty="cartGetters.getItemQty(product)"
                 :link="
                   localePath(
-                    `/p/${cartGetters.getItemSku(
+                    `/p/${cartGetters.getItemSku(product)}${cartGetters.getSlug(
                       product
-                    )}${cartGetters.getSlug(product)}`
+                    )}`
                   )
                 "
                 class="collected-product"
@@ -124,9 +129,7 @@
                   </div>
                 </template>
                 <template #configuration>
-                  <div
-                    v-if="getAttributes(product).length > 0"
-                  >
+                  <div v-if="getAttributes(product).length > 0">
                     <SfProperty
                       v-for="(attr, index) in getAttributes(product)"
                       :key="index"
@@ -134,9 +137,7 @@
                       :value="attr.value_label"
                     />
                   </div>
-                  <div
-                    v-if="getBundles(product).length > 0"
-                  >
+                  <div v-if="getBundles(product).length > 0">
                     <SfProperty
                       v-for="(bundle, i) in getBundles(product)"
                       :key="i"
@@ -165,7 +166,11 @@
               title="Your cart is empty"
               :level="2"
               class="empty-cart__heading"
-              :description="$t('Looks like you haven’t added any items to the bag yet. Start shopping to fill it in.')"
+              :description="
+                $t(
+                  'Looks like you haven’t added any items to the bag yet. Start shopping to fill it in.'
+                )
+              "
             />
           </div>
         </div>
@@ -175,15 +180,23 @@
           <div v-if="totalItems">
             <SfProperty
               :name="$t('Subtotal price')"
-              class="sf-property--full-width sf-property--large my-cart__total-price"
+              class="
+                sf-property--full-width sf-property--large
+                my-cart__total-price
+              "
             >
               <template #value>
                 <SfPrice
                   :regular="$n(totals.subtotal, 'currency')"
-                  :special="totals.subtotal <= totals.special ? '' : $n(totals.special, 'currency')"
+                  :special="
+                    totals.subtotal <= totals.special
+                      ? ''
+                      : $n(totals.special, 'currency')
+                  "
                 />
               </template>
             </SfProperty>
+            <CouponCode />
             <a @click="goToCheckout">
               <SfButton
                 v-e2e="'go-to-checkout-btn'"
@@ -230,6 +243,7 @@ import {
 import { onSSR } from '@vue-storefront/core';
 import { useUiState, useUiNotification } from '~/composables';
 import { useVueRouter } from '~/helpers/hooks/useVueRouter';
+import CouponCode from './CouponCode.vue';
 
 export default defineComponent({
   name: 'CartSidebar',
@@ -244,13 +258,11 @@ export default defineComponent({
     SfCollectedProduct,
     SfImage,
     SfQuantitySelector,
+    CouponCode,
   },
   setup() {
     const { initializeCheckout } = useExternalCheckout();
-    const {
-      isCartSidebarOpen,
-      toggleCartSidebar,
-    } = useUiState();
+    const { isCartSidebarOpen, toggleCartSidebar } = useUiState();
     const { router } = useVueRouter();
     const {
       cart,
@@ -260,10 +272,7 @@ export default defineComponent({
       loading,
     } = useCart();
     const { isAuthenticated } = useUser();
-    const {
-      send: sendNotification,
-      notifications,
-    } = useUiNotification();
+    const { send: sendNotification, notifications } = useUiNotification();
 
     const products = computed(() => cartGetters.getItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
@@ -302,7 +311,9 @@ export default defineComponent({
 
       sendNotification({
         id: Symbol('product_removed'),
-        message: `${cartGetters.getItemName(product)} has been successfully removed from your cart.`,
+        message: `${cartGetters.getItemName(
+          product,
+        )} has been successfully removed from your cart.`,
         type: 'success',
         icon: 'check',
         persist: false,
@@ -347,12 +358,12 @@ export default defineComponent({
   }
 }
 @include for-mobile {
-  .close-icon{
+  .close-icon {
     display: none;
   }
 }
 
-.close-icon{
+.close-icon {
   position: fixed;
   right: 10px;
   top: 10px;

--- a/packages/theme/components/Checkout/CartPreview.vue
+++ b/packages/theme/components/Checkout/CartPreview.vue
@@ -36,20 +36,7 @@
         class="sf-property--full-width sf-property--large property-total"
       />
     </div>
-    <div class="highlighted promo-code">
-      <SfInput
-        v-model="promoCode"
-        name="promoCode"
-        :label="$t('Enter promo code')"
-        class="sf-input--filled promo-code__input"
-      />
-      <SfButton
-        class="promo-code__button"
-        @click="handleCoupon"
-      >
-        {{ promoIsApplied ? $t('Remove') : $t('Apply') }}
-      </SfButton>
-    </div>
+    <CouponCode class="highlighted" />
     <div class="highlighted">
       <SfCharacteristic
         v-for="characteristic in characteristics"
@@ -63,22 +50,11 @@
   </div>
 </template>
 <script>
-import {
-  SfHeading,
-  SfButton,
-  SfProperty,
-  SfCharacteristic,
-  SfInput,
-} from '@storefront-ui/vue';
-import {
-  computed,
-  onMounted,
-  watch,
-  ref,
-  defineComponent,
-} from '@vue/composition-api';
+import { SfHeading, SfProperty, SfCharacteristic } from '@storefront-ui/vue';
+import { computed, ref, defineComponent } from '@vue/composition-api';
 import { useCart, cartGetters } from '@vue-storefront/magento';
 import getShippingMethodPrice from '~/helpers/checkout/getShippingMethodPrice';
+import CouponCode from '../CouponCode.vue';
 
 const CHARACTERISTICS = [
   {
@@ -88,8 +64,7 @@ const CHARACTERISTICS = [
   },
   {
     title: 'Easy shipping',
-    description:
-      'You’ll receive dispatch confirmation and an arrival date',
+    description: 'You’ll receive dispatch confirmation and an arrival date',
     icon: 'shipping',
   },
   {
@@ -103,50 +78,24 @@ export default defineComponent({
   name: 'CartPreview',
   components: {
     SfHeading,
-    SfButton,
     SfProperty,
     SfCharacteristic,
-    SfInput,
+    CouponCode,
   },
   setup() {
-    const {
-      cart,
-      removeItem,
-      updateItemQty,
-      applyCoupon,
-      removeCoupon,
-    } = useCart();
+    const { cart, removeItem, updateItemQty } = useCart();
 
     const listIsHidden = ref(false);
-    const promoCode = ref('');
-
-    const promoIsApplied = computed(() => cartGetters.getAppliedCoupon(cart.value)?.code);
 
     const products = computed(() => cartGetters.getItems(cart.value));
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const discounts = computed(() => cartGetters.getDiscounts(cart.value));
     const hasDiscounts = computed(() => discounts.value.length > 0);
-    const discountsAmount = computed(() => -1 * discounts.value.reduce((a, el) => el.value + a, 0));
+    const discountsAmount = computed(
+      () => -1 * discounts.value.reduce((a, el) => el.value + a, 0),
+    );
     const selectedShippingMethod = computed(() => cartGetters.getSelectedShippingMethod(cart.value));
-
-    const setCartCoupon = () => {
-      promoCode.value = promoIsApplied.value;
-    };
-
-    onMounted(setCartCoupon);
-
-    watch(promoIsApplied, setCartCoupon);
-
-    const handleCoupon = async () => {
-      await (
-        promoIsApplied.value
-          // @TODO - Remove ignore when https://github.com/vuestorefront/vue-storefront/issues/5966 is applied
-          // @ts-ignore
-          ? removeCoupon({ currentCart: cart.value })
-          : applyCoupon({ couponCode: promoCode.value })
-      );
-    };
 
     return {
       cart,
@@ -157,13 +106,10 @@ export default defineComponent({
       listIsHidden,
       products,
       totals,
-      promoCode,
       removeItem,
       updateItemQty,
       cartGetters,
       getShippingMethodPrice,
-      promoIsApplied,
-      handleCoupon,
       characteristics: CHARACTERISTICS,
       selectedShippingMethod,
     };
@@ -208,20 +154,4 @@ export default defineComponent({
     margin-bottom: var(--spacer-base);
   }
 }
-
-.promo-code {
-  display: flex;
-  align-items: flex-start;
-
-  &__button {
-    --button-width: 6.3125rem;
-    --button-height: var(--spacer-lg);
-  }
-
-  &__input {
-    --input-background: var(--c-white);
-    flex: 1;
-  }
-}
-
 </style>

--- a/packages/theme/components/CouponCode.vue
+++ b/packages/theme/components/CouponCode.vue
@@ -1,0 +1,112 @@
+<template>
+  <div>
+    <span
+      v-if="promoIsApplied"
+      class="applied-coupon"
+    >
+      {{ $t('Applied Coupon') }}:
+      <span class="applied-coupon__code">{{ promoCode }}</span>
+    </span>
+    <div class="promo-code">
+      <SfInput
+        v-model="promoCode"
+        name="promoCode"
+        :disabled="promoIsApplied"
+        :label="$t('Enter promo code')"
+        class="sf-input--filled promo-code__input"
+      />
+      <SfButton
+        class="promo-code__button"
+        @click="handleCoupon"
+      >
+        {{ promoIsApplied ? $t('Remove') : $t('Apply') }}
+      </SfButton>
+    </div>
+  </div>
+</template>
+
+<script>
+import { SfButton, SfInput } from '@storefront-ui/vue';
+import { useCart, cartGetters } from '@vue-storefront/magento';
+import {
+  computed,
+  onMounted,
+  watch,
+  ref,
+  defineComponent,
+} from '@vue/composition-api';
+
+export default defineComponent({
+  name: 'CouponCode',
+  components: {
+    SfButton,
+    SfInput,
+  },
+  setup() {
+    const { cart, applyCoupon, removeCoupon } = useCart();
+    const promoCode = ref('');
+    const promoIsApplied = computed(
+      () => cartGetters.getAppliedCoupon(cart.value)?.code,
+    );
+
+    const setCartCoupon = () => {
+      promoCode.value = promoIsApplied.value;
+    };
+
+    const handleCoupon = async () => {
+      await (promoIsApplied.value
+        ? removeCoupon({ currentCart: cart.value })
+        : applyCoupon({ couponCode: promoCode.value }));
+    };
+
+    onMounted(setCartCoupon);
+    watch(promoIsApplied, setCartCoupon);
+
+    return {
+      handleCoupon,
+      promoIsApplied,
+      promoCode,
+    };
+  },
+});
+</script>
+
+<style lang="scss" scoped>
+.applied-coupon {
+  &__code {
+    font-weight: bold;
+  }
+}
+.highlighted {
+  box-sizing: border-box;
+  width: 100%;
+  background-color: var(--c-light);
+  padding: var(--spacer-xl) var(--spacer-xl) 0;
+
+  &:last-child {
+    padding-bottom: var(--spacer-xl);
+  }
+
+  .promo-code {
+    &__input {
+      --input-background: var(--c-white);
+      flex: 1;
+    }
+  }
+}
+
+.promo-code {
+  display: flex;
+  align-items: flex-start;
+
+  &__button {
+    --button-width: 6.3125rem;
+    --button-height: var(--spacer-lg);
+  }
+
+  &__input {
+    --input-background: var(--c-light);
+    flex: 1;
+  }
+}
+</style>


### PR DESCRIPTION
## Description
- add coupon code in the sidebar cart so user can now input coupon from a sidebar cart
- coupon code and logi have been extracted to a new CouponCode component for a reusability

## Related Issue
#158 

## Motivation and Context
It solves request in related issue

## How Has This Been Tested?
- add something to cart
- open sidebar checkout and apply coupon
- coupon should be applied (if valid)
- observe if checkout cart preview coupon data is also updated

## Screenshots (if appropriate):
![Screenshot 2021-10-17 at 12 59 06](https://user-images.githubusercontent.com/16045377/137624464-864beab5-9503-4737-8c16-3206e74dc605.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
