### PR TITLE
fix(theme): remove duplicated api call

### DIFF
--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -10,19 +10,22 @@
         <div v-if="errorUseGetShippingMethods.load">
           {{
             $t(
-              'There was some error while trying to fetch shipping methods. We are sorry, please try with different shipping details or later.')
+              'There was some error while trying to fetch shipping methods. We are sorry, please try with different shipping details or later.'
+            )
           }}
         </div>
         <div v-else-if="errorShippingProvider.save">
           {{
             $t(
-              'There was some error while trying to select this shipping method. We are sorry, please try with different shipping method or later.')
+              'There was some error while trying to select this shipping method. We are sorry, please try with different shipping method or later.'
+            )
           }}
         </div>
         <div v-else-if="shippingMethods.length === 0">
           {{
             $t(
-              'There are no shipping methods available for this country. We are sorry, please try with different country or later.')
+              'There are no shipping methods available for this country. We are sorry, please try with different country or later.'
+            )
           }}
         </div>
       </SfLoader>
@@ -33,7 +36,10 @@
           v-e2e="'shipping-method-label'"
           :label="method.method_title"
           :value="method.method_code"
-          :selected="selectedShippingMethod && selectedShippingMethod.method_code"
+          :selected="
+            selectedShippingMethod &&
+            selectedShippingMethod.method_code
+          "
           name="shippingMethod"
           :description="method.carrier_title"
           class="form__radio shipping"
@@ -61,7 +67,11 @@
           v-e2e="'continue-to-billing'"
           class="form__action-button"
           type="button"
-          :disabled="!isShippingMethodStepCompleted || isLoading || loadingShippingProvider.save"
+          :disabled="
+            !isShippingMethodStepCompleted ||
+            isLoading ||
+            loadingShippingProvider.save
+          "
           @click="$emit('submit')"
         >
           {{ $t('Continue to billing') }}
@@ -78,12 +88,7 @@ import {
   cartGetters,
   useGetShippingMethods,
 } from '@vue-storefront/magento';
-import {
-  SfHeading,
-  SfButton,
-  SfRadio,
-  SfLoader,
-} from '@storefront-ui/vue';
+import { SfHeading, SfButton, SfRadio, SfLoader } from '@storefront-ui/vue';
 
 import { computed, defineComponent } from '@vue/composition-api';
 import getShippingMethodPrice from '~/helpers/checkout/getShippingMethodPrice';
@@ -107,22 +112,24 @@ export default defineComponent({
       state,
       error: errorShippingProvider,
       loading: loadingShippingProvider,
-      save,
+      setState,
     } = useShippingProvider();
     const selectedShippingMethod = computed(() => state.value);
     const totals = computed(() => cartGetters.getTotals(cart.value));
-    const isLoading = computed(() => loadingShippingMethods.value || loadingShippingProvider.value);
-    const isShippingMethodStepCompleted = computed(() => state.value?.method_code && !isLoading.value);
+    const isLoading = computed(
+      () => loadingShippingMethods.value || loadingShippingProvider.value
+    );
+    const isShippingMethodStepCompleted = computed(
+      () => state.value?.method_code && !isLoading.value
+    );
     /**
      * @TODO: Do not run the setShippingMethodsOnCart mutation on in-store pickup orders.
      * Instead, specify the pickup_location_code attribute in the setShippingAddressesOnCart mutation.
      */
     const selectShippingMethod = async (method) => {
-      await save({
-        shippingMethod: {
-          carrier_code: method.carrier_code,
-          method_code: method.method_code,
-        },
+      await setState({
+        carrier_code: method.carrier_code,
+        method_code: method.method_code,
       });
     };
 
@@ -190,7 +197,6 @@ export default defineComponent({
     @include for-desktop {
       margin: 0 0 var(--spacer-2xl) 0;
     }
-
   }
 }
 </style>


### PR DESCRIPTION
Remove duplicated api call

## Description
When user choose the shipping adress, the shipping method api was called, but following the api magento guide, the shipping method should be called after user choose the billing address.

I changed the method that was called when user choose the shipping address to not call shipping method api yeat, it will just set the value of choosed shipping method and after choose the billing address the shipping method will be called.

The 'save' API was called twice during the Checkout process. At this step, it should only store the data using setState, not call the API.

## Related Issue
To reproduce the problem, add an item to a cart.
When you are doing the checkout process, pay attention at network tab on devtools, and notice that when you choose your shipping address the shipping method will be called.

The issue is about calling the shipping method when billing address is changed, but its correct. The problem is when you choose the shipping address the shipping method shouldn't called yeat.

https://github.com/vuestorefront/magento2/issues/220

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
