### PR TITLE
refactor(api-client): enable default useGETForQueries to true for apo…

### DIFF
--- a/packages/api-client/src/helpers/magentoLink/graphQl.ts
+++ b/packages/api-client/src/helpers/magentoLink/graphQl.ts
@@ -52,7 +52,12 @@ export const apolloLinkFactory = (settings: Config, handlers?: {
     },
   }));
 
-  const httpLink = createHttpLink({ uri: settings.api, fetch });
+  const httpLink = createHttpLink({
+    uri: settings.api,
+    fetch,
+    useGETForQueries: true,
+    ...settings.customApolloHttpLinkOptions,
+  });
 
   const onErrorLink = createErrorHandler();
 

--- a/packages/api-client/src/types/setup.ts
+++ b/packages/api-client/src/types/setup.ts
@@ -1,4 +1,5 @@
 import ApolloClient, { ApolloClientOptions } from 'apollo-client';
+import { FetchOptions } from 'apollo-link-http';
 import { MagentoApiMethods } from './API';
 
 export interface Storage {
@@ -76,6 +77,7 @@ export interface Config<T = any> extends ClientConfig {
   client?: ApolloClient<T>;
   storage: Storage;
   customOptions?: ApolloClientOptions<any>;
+  customApolloHttpLinkOptions?: FetchOptions;
   overrides: MagentoApiMethods;
 }
 


### PR DESCRIPTION
enable default useGETForQueries to true for apollo-http-link

<!--- Provide a general summary of your changes in the Title above -->

## Description
With the Caudalie team, we saw that the magento2 endpoint is receiving GraphQL GET and POST requests.
Magento requires receiving GET GraphQL to be cached.

https://devdocs.magento.com/guides/v2.4/graphql/caching.html

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is needed to be able to benefit of the full caching performance from GraphQL.
We have experienced from 3s~ to 300ms~ with this configuration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before : 
![Capture d’écran 2021-11-04 à 23 54 46](https://user-images.githubusercontent.com/16859411/140431402-5e0ed3f1-067a-4028-b55c-e48d8649f29f.png)
After : 
![Capture d’écran 2021-11-04 à 23 57 19](https://user-images.githubusercontent.com/16859411/140431639-85599014-35f2-4bf7-a472-a771709e3e59.png)
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
