### PR TITLE
fix(theme): update cart item key to stop rendering

### DIFF
--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -93,7 +93,7 @@
             >
               <SfCollectedProduct
                 v-for="product in products"
-                :key="`${cartGetters.getItemSku(product)}-${Math.random()}`"
+                :key="cartGetters.getItemSku(product)"
                 :image="cartGetters.getItemImage(product)"
                 :title="cartGetters.getItemName(product)"
                 :regular-price="


### PR DESCRIPTION
## Description
Updated <SfCollectedProduct> v-for :key to remove 'math.random' as this was regenerating unique keys and causing the cart item to re-render when updating quantity. Magento product SKUs are unique so all items will have a unique key without this.

## Related Issue
https://github.com/vuestorefront/magento2/issues/287

## Motivation and Context
Improve user experience to stop content in the cart sidebar from jumping around

## How Has This Been Tested?
Change tested on a new install of the latest VSF version, with clean Magento install using sample data

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
