### PR TITLE
refactor: updated the usage of `customQuery` and applied correct params

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -56,6 +56,7 @@ module.exports = {
         children: [
           ['/', 'Introduction'],
           ['/guide/environments', 'Environments'],
+          ['/guide/functional-catalog', 'Functional catalog'],
           ['/guide/about', 'About'],
         ]
       },

--- a/docs/guide/functional-catalog.md
+++ b/docs/guide/functional-catalog.md
@@ -1,0 +1,111 @@
+# Functional Catalog
+
+This page shows the current feature set of Magento 2 - Vue Storefront 2 integration
+
+## Product types
+
+|  Product type | Is supported |
+|---------------|--------------|
+| Simple        | Yes 💚       |
+| Grouped       | Yes 💚       |
+| Configurable  | Yes 💚       |
+| Bundle        | Yes 💚       |
+| Virtual       | Partial 🧡   |
+| Downloadable  | Partial 🧡   |
+
+### Note
+
+Virtual products are visible on the storefront, and a user can add them to the cart.
+We have to modify the checkout and hide the shipping step when virtual products are in the cart.
+
+## CMS content
+
+|  Feature      | Is supported |
+|---------------|--------------|
+| CMS Pages     | Yes 💚       |
+| CMS Blocks    | Yes 💚       |
+| CMS Widgets   | Partial 🧡   |
+| Page Builder  | No ❌        |
+
+### Note
+
+Support for Page Builder is planned for version 1.1.
+Anyway, we have a few ready to go integrations with headless Content Management Systems
+
+## Category & Search Results Page
+
+|  Feature                      | Is supported |
+|-------------------------------|--------------|
+| Quick search                  | Yes 💚       |
+| Grid/list mode                | Yes 💚       |
+| Adding product to cart        | Yes 💚       |
+| Adding product to wishlist    | Yes 💚       |
+| Configurable product swatches | No  ❌       |
+| Filtering                     | Yes 💚       |
+| Sorting                       | Yes 💚       |
+| Breadcrumb                    | No  ❌       |
+| Category Landing Pages        | No  ❌       |
+
+## Product page
+
+|  Feature                      | Is supported |
+|-------------------------------|--------------|
+| Breadcrumb                    | Yes 💚       |
+| Pricing                       | Yes 💚       |
+| Special pricing               | Yes 💚       |
+| Product swatches              | Yes 💚       |
+| Customizable product options  | No  ❌       |
+| Image gallery                 | Yes 💚       |
+| Video in gallery              | No  ❌       |
+| Add to wishlist               | Yes 💚       |
+| Add to compare                | No  ❌       |
+| Customer Reviews              | Yes 💚       |
+| Adding a new review           | Yes 💚       |
+| Product description           | Yes 💚       |
+| Product short description     | Yes 💚       |
+| Related products              | Yes 💚       |
+| Up-sell products              | Yes 💚       |
+
+## Checkout process
+
+|  Feature                      | Is supported |
+|-------------------------------|--------------|
+| Mini Cart                     | Yes 💚       |
+| Standalone cart page          | No  ❌       |
+| Checkout - shipping step      | Yes 💚       |
+| Checkout - payment step       | Yes 💚       |
+| In-Store delivery             | No  ❌       |
+| Shipping methods              | Partial 🧡   |
+| Payment methods               | Partial 🧡   |
+
+## Customer account
+
+|  Feature                      | Is supported |
+|-------------------------------|--------------|
+| Account Information           | Yes 💚       |
+| Order history                 | Yes 💚       |
+| Order detail view             | Yes 💚       |
+| Re-order                      | No  ❌       |
+| Invoices                      | No  ❌       |
+| Returns                       | No  ❌       |
+| Order shipments               | No  ❌       |
+| Print order                   | No  ❌       |
+| Downloadable products         | No  ❌       |
+| Wishlist                      | Yes 💚       |
+| Address book                  | Yes 💚       |
+| Stored payment methods        | No  ❌       |
+| Reviews                       | Yes 💚       |
+| Newsletter subscription       | Yes 💚       |
+
+## Other features
+
+|  Feature                      | Is supported |
+|-------------------------------|--------------|
+| Internationalization          | Yes 💚       |
+| Multistore                    | Partial 🧡   |
+| Mega menu                     | Yes 💚       |
+| Product comparison            | No  ❌       |
+
+
+If you have any suggestions about the roadmap, or you want to some features here,
+please reach us out on our Discord channel.

--- a/packages/api-client/src/api/changeCustomerPassword/index.ts
+++ b/packages/api-client/src/api/changeCustomerPassword/index.ts
@@ -9,8 +9,7 @@ import { Context } from '../../types/context';
 
 export default async (
   context: Context,
-  currentPassword: string,
-  newPassword: string,
+  params: { currentPassword: string; newPassword: string; },
   customQuery: CustomQuery = { changeCustomerPassword: 'changeCustomerPassword' },
 ): Promise<FetchResult<ChangeCustomerPasswordMutation>> => {
   try {
@@ -20,8 +19,8 @@ export default async (
         changeCustomerPassword: {
           query: changeCustomerPassword,
           variables: {
-            currentPassword,
-            newPassword,
+            currentPassword: params.currentPassword,
+            newPassword: params.newPassword,
           },
         },
       },

--- a/packages/api-client/src/api/generateCustomerToken/index.ts
+++ b/packages/api-client/src/api/generateCustomerToken/index.ts
@@ -9,8 +9,10 @@ import { Context } from '../../types/context';
 
 export default async (
   context: Context,
-  email: string,
-  password: string,
+  params: {
+    email: string;
+    password: string;
+  },
   customQuery: CustomQuery = { generateCustomerToken: 'generateCustomerToken' },
 ): Promise<FetchResult<GenerateCustomerTokenMutation>> => {
   try {
@@ -20,8 +22,8 @@ export default async (
         generateCustomerToken: {
           query: generateCustomerToken,
           variables: {
-            email,
-            password,
+            email: params.email,
+            password: params.password,
           },
         },
       },

--- a/packages/api-client/src/api/mergeCarts/index.ts
+++ b/packages/api-client/src/api/mergeCarts/index.ts
@@ -6,8 +6,10 @@ import { Context } from '../../types/context';
 
 export default async (
   context: Context,
-  sourceCartId: string,
-  destinationCartId: string,
+  params: {
+    sourceCartId: string;
+    destinationCartId: string;
+  },
   customQuery: CustomQuery = { mergeCarts: 'mergeCarts' },
 ): Promise<FetchResult<MergeCartsMutation>> => {
   const { mergeCarts: mergeCartsGQL } = context.extendQuery(
@@ -16,8 +18,8 @@ export default async (
       mergeCarts: {
         query: mergeCarts,
         variables: {
-          sourceCartId,
-          destinationCartId,
+          sourceCartId: params.sourceCartId,
+          destinationCartId: params.destinationCartId,
         },
       },
     },

--- a/packages/api-client/src/types/API.ts
+++ b/packages/api-client/src/types/API.ts
@@ -165,148 +165,275 @@ export enum MagentoCustomerGender {
 }
 
 export interface MagentoApiMethods {
-  addBundleProductsToCart(input: AddBundleProductsToCartInput): Promise<FetchResult<AddBundleProductsToCartMutation>>;
+  addBundleProductsToCart(
+    input: AddBundleProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddBundleProductsToCartMutation>>;
 
-  addConfigurableProductsToCart(input: AddConfigurableProductsToCartInput): Promise<FetchResult<AddConfigurableProductsToCartMutation>>;
+  addConfigurableProductsToCart(
+    input: AddConfigurableProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddConfigurableProductsToCartMutation>>;
 
-  addProductsToCart(input: AddProductsToCartInput): Promise<FetchResult<AddProductsToCartMutation>>;
+  addProductsToCart(
+    input: AddProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddProductsToCartMutation>>;
 
-  addProductToWishList(input: AddProductsToWishlistMutationVariables): Promise<FetchResult<AddProductsToWishlistMutation>>;
+  addProductToWishList(
+    input: AddProductsToWishlistMutationVariables,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddProductsToWishlistMutation>>;
 
-  addSimpleProductsToCart(input: AddSimpleProductsToCartInput): Promise<FetchResult<AddSimpleProductsToCartMutation>>;
+  addSimpleProductsToCart(
+    input: AddSimpleProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddSimpleProductsToCartMutation>>;
 
-  addDownloadableProductsToCart(input: AddDownloadableProductsToCartInput): Promise<FetchResult<AddDownloadableProductsToCartMutation>>;
+  addDownloadableProductsToCart(
+    input: AddDownloadableProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddDownloadableProductsToCartMutation>>;
 
-  addVirtualProductsToCart(input: AddVirtualProductsToCartInput): Promise<FetchResult<AddVirtualProductsToCartMutation>>;
+  addVirtualProductsToCart(
+    input: AddVirtualProductsToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<AddVirtualProductsToCartMutation>>;
 
-  applyCouponToCart(input: ApplyCouponToCartInput): Promise<FetchResult<ApplyCouponToCartMutation>>;
+  applyCouponToCart(
+    input: ApplyCouponToCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<ApplyCouponToCartMutation>>;
 
-  availableStores(): Promise<ApolloQueryResult<AvailableStoresQuery>>;
+  availableStores(customQuery?: CustomQuery): Promise<ApolloQueryResult<AvailableStoresQuery>>;
 
-  cart(cartId: string): Promise<ApolloQueryResult<CartQuery>>;
+  cart(
+    cartId: string,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CartQuery>>;
 
-  categoryList(categoryFilter?: CategoryListQueryVariables): Promise<ApolloQueryResult<CategoryListQuery>>;
+  categoryList(
+    categoryFilter?: CategoryListQueryVariables,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CategoryListQuery>>;
 
-  categorySearch(categoryFilter?: CategorySearchQueryVariables): Promise<ApolloQueryResult<CategorySearchQuery>>;
+  categorySearch(
+    categoryFilter?: CategorySearchQueryVariables,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CategorySearchQuery>>;
 
-  changeCustomerPassword(currentPassword: string, newPassword: string): Promise<FetchResult<ChangeCustomerPasswordMutation>>;
+  changeCustomerPassword(
+    params: { currentPassword: string; newPassword: string },
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<ChangeCustomerPasswordMutation>>;
 
-  cmsBlocks(identifiers: string[]): Promise<ApolloQueryResult<CmsBlockQuery>>;
+  cmsBlocks(
+    identifiers: string[],
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CmsBlockQuery>>;
 
-  cmsPage(identifier: string): Promise<ApolloQueryResult<CmsPageQuery>>;
+  cmsPage(
+    identifier: string,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CmsPageQuery>>;
 
-  countries(): Promise<ApolloQueryResult<CountriesListQuery>>;
+  countries(customQuery?: CustomQuery): Promise<ApolloQueryResult<CountriesListQuery>>;
 
-  country(id: string): Promise<ApolloQueryResult<CountryInformationQuery>>;
+  country(
+    id: string,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CountryInformationQuery>>;
 
-  createCustomer(input: CustomerCreateInput): Promise<FetchResult<CreateCustomerMutation>>;
+  createCustomer(
+    input: CustomerCreateInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<CreateCustomerMutation>>;
 
-  createCustomerAddress(input: CustomerAddressInput): Promise<FetchResult<CreateCustomerAddressMutation>>;
+  createCustomerAddress(
+    input: CustomerAddressInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<CreateCustomerAddressMutation>>;
 
-  createEmptyCart(): Promise<FetchResult<CreateEmptyCartMutation>>;
+  createEmptyCart(customQuery?: CustomQuery): Promise<FetchResult<CreateEmptyCartMutation>>;
 
-  createProductReview(input: CreateProductReviewInput): Promise<FetchResult<CreateProductReviewMutation>>;
+  createProductReview(
+    input: CreateProductReviewInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<CreateProductReviewMutation>>;
 
-  currency(): Promise<FetchResult<CurrencyQuery>>
+  currency(customQuery?: CustomQuery): Promise<FetchResult<CurrencyQuery>>
 
-  customer(): Promise<ApolloQueryResult<CustomerQuery>>;
+  customer(customQuery?: CustomQuery): Promise<ApolloQueryResult<CustomerQuery>>;
 
-  customerCart(): Promise<ApolloQueryResult<CustomerCartQuery>>;
+  customerCart(customQuery?: CustomQuery): Promise<ApolloQueryResult<CustomerCartQuery>>;
 
   customerOrders(
     searchParams: GetOrdersSearchParams,
     customQuery?: CustomQuery,
   ): Promise<ApolloQueryResult<CustomerOrdersQuery>>;
 
-  customQuery<QUERY = any, QUERY_VARIABLES = any>({
-    query,
-    queryVariables,
-    fetchPolicy,
-  }: {
+  customQuery<QUERY = any, QUERY_VARIABLES = any>(params: {
     query: QUERY,
     queryVariables?: QUERY_VARIABLES,
     fetchPolicy?: FetchPolicy,
   }): Promise<ApolloQueryResult<QUERY>>;
 
-  customMutation<MUTATION = any, MUTATION_VARIABLES = any>({
-    mutation,
-    mutationVariables,
-    fetchPolicy,
-  }: {
+  customMutation<MUTATION = any, MUTATION_VARIABLES = any>(params: {
     mutation: MUTATION,
     mutationVariables: MUTATION_VARIABLES,
     fetchPolicy?: Extract<FetchPolicy, 'network-only' | 'no-cache'>,
   }): Promise<FetchResult<MUTATION>>;
 
-  customerProductReview(input: CustomerProductReviewParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<CustomerProductReviewQuery>>;
+  customerProductReview(
+    input: CustomerProductReviewParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<CustomerProductReviewQuery>>;
 
-  deleteCustomerAddress(addressId: number): Promise<ExecutionResult<DeleteCustomerAddressMutation>>;
+  deleteCustomerAddress(
+    addressId: number,
+    customQuery?: CustomQuery
+  ): Promise<ExecutionResult<DeleteCustomerAddressMutation>>;
 
-  generateCustomerToken(email: string, password: string): Promise<FetchResult<GenerateCustomerTokenMutation>>;
+  generateCustomerToken(
+    params: { email: string, password: string },
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<GenerateCustomerTokenMutation>>;
 
   getAvailableCustomerPaymentMethods(customQuery?: CustomQuery): Promise<ApolloQueryResult<CustomerAvailablePaymentMethodsQuery>>;
 
   getAvailableCustomerShippingMethods(customQuery?: CustomQuery): Promise<ApolloQueryResult<CustomerAvailableShippingMethodsQuery>>;
 
-  getAvailablePaymentMethods(params: { cartId: string }, customQuery?: CustomQuery): Promise<ApolloQueryResult<GuestAvailablePaymentMethodsQuery>>;
+  getAvailablePaymentMethods(
+    params: { cartId: string },
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<GuestAvailablePaymentMethodsQuery>>;
 
-  getAvailableShippingMethods(params: { cartId: string }, customQuery?: CustomQuery): Promise<ApolloQueryResult<GuestAvailableShippingMethodsQuery>>;
+  getAvailableShippingMethods(
+    params: { cartId: string },
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<GuestAvailableShippingMethodsQuery>>;
 
   getCustomerAddresses(customQuery?: CustomQuery): Promise<ApolloQueryResult<GetCustomerAddressesQuery>>;
 
-  mergeCarts(sourceCartId: string, destinationCartId: string): Promise<FetchResult<MergeCartsMutation>>;
+  mergeCarts(
+    params: { sourceCartId: string; destinationCartId: string },
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<MergeCartsMutation>>;
 
-  placeOrder(input: PlaceOrderInput): Promise<FetchResult<PlaceOrderMutation>>;
+  placeOrder(
+    input: PlaceOrderInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<PlaceOrderMutation>>;
 
-  productDetail(searchParams: GetProductSearchParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<ProductDetailsQuery>>;
+  productDetail(
+    searchParams: GetProductSearchParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<ProductDetailsQuery>>;
 
-  productReview(searchParams: GetProductSearchParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<ProductReviewQuery>>;
+  productReview(
+    searchParams: GetProductSearchParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<ProductReviewQuery>>;
 
-  productReviewRatingsMetadata(): Promise<ApolloQueryResult<ProductReviewRatingsMetadataQuery>>;
+  productReviewRatingsMetadata(customQuery?: CustomQuery): Promise<ApolloQueryResult<ProductReviewRatingsMetadataQuery>>;
 
-  products(searchParams: GetProductSearchParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<ProductsListQuery>>;
+  products(
+    searchParams: GetProductSearchParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<ProductsListQuery>>;
 
-  relatedProduct(searchParams: GetProductSearchParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<RelatedProductQuery>>;
+  relatedProduct(
+    searchParams: GetProductSearchParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<RelatedProductQuery>>;
 
-  removeCouponFromCart(input: RemoveCouponFromCartInput): Promise<FetchResult<RemoveCouponFromCartMutation>>;
+  removeCouponFromCart(
+    input: RemoveCouponFromCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<RemoveCouponFromCartMutation>>;
 
-  removeItemFromCart(input: RemoveItemFromCartInput): Promise<FetchResult<RemoveItemFromCartMutation>>;
+  removeItemFromCart(
+    input: RemoveItemFromCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<RemoveItemFromCartMutation>>;
 
-  removeProductsFromWishlist(input: RemoveProductsFromWishlistMutationVariables): Promise<FetchResult<RemoveProductsFromWishlistMutation>>;
+  removeProductsFromWishlist(
+    input: RemoveProductsFromWishlistMutationVariables,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<RemoveProductsFromWishlistMutation>>;
 
-  revokeCustomerToken(): Promise<FetchResult<RevokeCustomerTokenMutation>>;
+  revokeCustomerToken(customQuery?: CustomQuery): Promise<FetchResult<RevokeCustomerTokenMutation>>;
 
   requestPasswordResetEmail(
     input: RequestPasswordResetEmailMutationVariables,
     customQuery?: CustomQuery): Promise<FetchResult<RequestPasswordResetEmailMutation>>;
 
-  resetPassword(input: ResetPasswordMutationVariables, customQuery?: CustomQuery,): Promise<FetchResult<ResetPasswordMutation>>;
+  resetPassword(
+    input: ResetPasswordMutationVariables,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<ResetPasswordMutation>>;
 
-  setBillingAddressOnCart(input: SetBillingAddressOnCartInput): Promise<FetchResult<SetBillingAddressOnCartMutation>>;
+  setBillingAddressOnCart(
+    input: SetBillingAddressOnCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SetBillingAddressOnCartMutation>>;
 
-  setGuestEmailOnCart(input: SetGuestEmailOnCartInput): Promise<FetchResult<SetGuestEmailOnCartMutation>>;
+  setGuestEmailOnCart(
+    input: SetGuestEmailOnCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SetGuestEmailOnCartMutation>>;
 
-  setPaymentMethodOnCart(input: SetPaymentMethodOnCartInputs): Promise<FetchResult<SetPaymentMethodOnCartMutation>>;
+  setPaymentMethodOnCart(
+    input: SetPaymentMethodOnCartInputs,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SetPaymentMethodOnCartMutation>>;
 
-  setShippingAddressesOnCart(input: SetShippingAddressesOnCartInput): Promise<FetchResult<SetShippingAddressesOnCartMutation>>;
+  setShippingAddressesOnCart(
+    input: SetShippingAddressesOnCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SetShippingAddressesOnCartMutation>>;
 
-  setShippingMethodsOnCart(input: SetShippingMethodsOnCartInput): Promise<FetchResult<SetShippingMethodsOnCartMutation>>;
+  setShippingMethodsOnCart(
+    input: SetShippingMethodsOnCartInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SetShippingMethodsOnCartMutation>>;
 
-  storeConfig(): Promise<ApolloQueryResult<StoreConfigQuery>>;
+  storeConfig(customQuery?: CustomQuery): Promise<ApolloQueryResult<StoreConfigQuery>>;
 
-  subscribeEmailToNewsletter(input: SubscribeEmailToNewsletterMutationVariables): Promise<FetchResult<SubscribeEmailToNewsletterMutation>>;
+  subscribeEmailToNewsletter(
+    input: SubscribeEmailToNewsletterMutationVariables,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<SubscribeEmailToNewsletterMutation>>;
 
-  updateCartItems(input: UpdateCartItemsInput): Promise<FetchResult<UpdateCartItemsMutation>>;
+  updateCartItems(
+    input: UpdateCartItemsInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<UpdateCartItemsMutation>>;
 
-  updateCustomer(input: CustomerUpdateInput): Promise<FetchResult<UpdateCustomerMutation>>;
+  updateCustomer(
+    input: CustomerUpdateInput,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<UpdateCustomerMutation>>;
 
-  updateCustomerAddress(input: { addressId: number; input: CustomerAddressInput; }): Promise<FetchResult<UpdateCustomerAddressMutation>>;
+  updateCustomerAddress(
+    input: { addressId: number; input: CustomerAddressInput; },
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<UpdateCustomerAddressMutation>>;
 
-  updateCustomerEmail(input: UpdateCustomerEmailMutationVariables): Promise<FetchResult<UpdateCustomerAddressMutation>>;
+  updateCustomerEmail(
+    input: UpdateCustomerEmailMutationVariables,
+    customQuery?: CustomQuery
+  ): Promise<FetchResult<UpdateCustomerAddressMutation>>;
 
-  upsellProduct(searchParams: GetProductSearchParams, customQuery?: CustomQuery): Promise<ApolloQueryResult<UpsellProductsQuery>>;
+  upsellProduct(
+    searchParams: GetProductSearchParams,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<UpsellProductsQuery>>;
 
-  urlResolver(url: string): Promise<ApolloQueryResult<UrlResolverQuery>>;
+  urlResolver(
+    url: string,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<UrlResolverQuery>>;
 
   wishlist(
     searchParams: WishlistQueryVariables,

--- a/packages/composables/src/composables/useAddresses/index.ts
+++ b/packages/composables/src/composables/useAddresses/index.ts
@@ -39,7 +39,10 @@ RemoveAddressInput> = {
   },
   save: async (context: Context, saveParams) => {
     Logger.debug('[Magento] save user address:', saveParams.address);
-    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(saveParams));
+    const { data } = await context.$magento.api.createCustomerAddress(
+      transformUserCreateAddressInput(saveParams),
+      saveParams.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 
@@ -48,7 +51,10 @@ RemoveAddressInput> = {
   remove: async (context: Context, params) => {
     Logger.debug('[Magento] remove user addresses');
 
-    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id);
+    const { data } = await context.$magento.api.deleteCustomerAddress(
+      params.address.id,
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 
@@ -57,7 +63,10 @@ RemoveAddressInput> = {
   update: async (context: Context, params) => {
     Logger.debug('[Magento] update user addresses', params);
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params));
+    const { data } = await context.$magento.api.updateCustomerAddress(
+      transformUserUpdateAddressInput(params),
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useAddresses/index.ts
+++ b/packages/composables/src/composables/useAddresses/index.ts
@@ -41,7 +41,7 @@ RemoveAddressInput> = {
     Logger.debug('[Magento] save user address:', saveParams.address);
     const { data } = await context.$magento.api.createCustomerAddress(
       transformUserCreateAddressInput(saveParams),
-      saveParams.customQuery || {},
+      saveParams?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });
@@ -53,7 +53,7 @@ RemoveAddressInput> = {
 
     const { data } = await context.$magento.api.deleteCustomerAddress(
       params.address.id,
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });
@@ -65,7 +65,7 @@ RemoveAddressInput> = {
 
     const { data } = await context.$magento.api.updateCustomerAddress(
       transformUserUpdateAddressInput(params),
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });

--- a/packages/composables/src/composables/useBilling/index.ts
+++ b/packages/composables/src/composables/useBilling/index.ts
@@ -18,11 +18,11 @@ const factoryParams: UseBillingParams<any, any> = {
     };
   },
 
-  load: async (context: Context, { customQuery }) => {
+  load: async (context: Context, params) => {
     Logger.debug('[Magento] loadBilling');
 
     if (!context.cart.cart?.value?.billing_address) {
-      await context.cart.load({ customQuery });
+      await context.cart.load({ customQuery: params?.customQuery || {} });
     }
 
     return context.cart.cart.value.billing_address;
@@ -61,7 +61,7 @@ const factoryParams: UseBillingParams<any, any> = {
 
     const { data } = await context.$magento.api.setBillingAddressOnCart(
       setBillingAddressOnCartInput,
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });

--- a/packages/composables/src/composables/useBilling/index.ts
+++ b/packages/composables/src/composables/useBilling/index.ts
@@ -35,6 +35,8 @@ const factoryParams: UseBillingParams<any, any> = {
 
     const {
       apartment,
+      neighborhood,
+      extra,
       sameAsShipping,
       customerAddressId,
       ...address
@@ -47,7 +49,7 @@ const factoryParams: UseBillingParams<any, any> = {
       : ({
         address: {
           ...address,
-          street: [address.street, apartment],
+          street: [address.street, apartment, neighborhood, extra],
         },
         same_as_shipping: sameAsShipping,
       });
@@ -57,7 +59,10 @@ const factoryParams: UseBillingParams<any, any> = {
       billing_address: billingData,
     };
 
-    const { data } = await context.$magento.api.setBillingAddressOnCart(setBillingAddressOnCartInput);
+    const { data } = await context.$magento.api.setBillingAddressOnCart(
+      setBillingAddressOnCartInput,
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useCart/index.ts
+++ b/packages/composables/src/composables/useCart/index.ts
@@ -1,6 +1,7 @@
 /* istanbul ignore file */
 /* eslint-disable no-param-reassign */
 import {
+  ComposableFunctionArgs,
   Context,
   Logger,
 } from '@vue-storefront/core';
@@ -21,10 +22,9 @@ import {
 } from '../../factories/useCartFactory';
 
 const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
-  load: async (context: Context, params: {
-    customQuery?: any;
+  load: async (context: Context, params: ComposableFunctionArgs<{
     realCart?: boolean;
-  }) => {
+  }>) => {
     const apiState = context.$magento.config.state;
     Logger.debug('[Magento Storefront]: Loading Cart');
 
@@ -38,7 +38,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
 
       apiState.setCartId();
 
-      const { data } = await context.$magento.api.createEmptyCart();
+      const { data } = await context.$magento.api.createEmptyCart(params.customQuery || {});
       Logger.debug('[Result]:', { data });
 
       apiState.setCartId(data.createEmptyCart);
@@ -49,7 +49,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     const getCartData = async (id: string) => {
       Logger.debug('[Magento Storefront]: useCart.load.getCartData ID->', id);
 
-      const { data, errors } = await context.$magento.api.cart(id);
+      const { data, errors } = await context.$magento.api.cart(id, params.customQuery || {});
       Logger.debug('[Result]:', { data });
 
       if (!data?.cart && errors?.length) {
@@ -75,7 +75,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     // Try to load cart for existing customer, clean customer token if not possible
     if (customerToken) {
       try {
-        const { data, errors } = await context.$magento.api.customerCart();
+        const { data, errors } = await context.$magento.api.customerCart(params.customQuery || {});
         Logger.debug('[Result]:', { data, errors });
 
         if (!data?.customerCart && errors?.length) {

--- a/packages/composables/src/composables/useCart/index.ts
+++ b/packages/composables/src/composables/useCart/index.ts
@@ -38,7 +38,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
 
       apiState.setCartId();
 
-      const { data } = await context.$magento.api.createEmptyCart(params.customQuery || {});
+      const { data } = await context.$magento.api.createEmptyCart(params?.customQuery || {});
       Logger.debug('[Result]:', { data });
 
       apiState.setCartId(data.createEmptyCart);
@@ -49,7 +49,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     const getCartData = async (id: string) => {
       Logger.debug('[Magento Storefront]: useCart.load.getCartData ID->', id);
 
-      const { data, errors } = await context.$magento.api.cart(id, params.customQuery || {});
+      const { data, errors } = await context.$magento.api.cart(id, params?.customQuery || {});
       Logger.debug('[Result]:', { data });
 
       if (!data?.cart && errors?.length) {
@@ -75,7 +75,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     // Try to load cart for existing customer, clean customer token if not possible
     if (customerToken) {
       try {
-        const { data, errors } = await context.$magento.api.customerCart(params.customQuery || {});
+        const { data, errors } = await context.$magento.api.customerCart(params?.customQuery || {});
         Logger.debug('[Result]:', { data, errors });
 
         if (!data?.customerCart && errors?.length) {

--- a/packages/composables/src/composables/useCategory/index.ts
+++ b/packages/composables/src/composables/useCategory/index.ts
@@ -11,7 +11,7 @@ const factoryParams: UseCategoryFactoryParams<Category, CategoryListQueryVariabl
   categorySearch: async (context: Context, params) => {
     Logger.debug('[Magento]: List available categories', { params });
 
-    const { data } = await context.$magento.api.categoryList(params, params.customQuery || {});
+    const { data } = await context.$magento.api.categoryList(params, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useCategory/index.ts
+++ b/packages/composables/src/composables/useCategory/index.ts
@@ -4,14 +4,14 @@ import {
   UseCategoryFactoryParams, Logger,
 } from '@vue-storefront/core';
 import {
-  Category,
+  Category, CategoryListQueryVariables,
 } from '@vue-storefront/magento-api';
 
-const factoryParams: UseCategoryFactoryParams<Category, any> = {
+const factoryParams: UseCategoryFactoryParams<Category, CategoryListQueryVariables> = {
   categorySearch: async (context: Context, params) => {
     Logger.debug('[Magento]: List available categories', { params });
 
-    const { data } = await context.$magento.api.categoryList(params);
+    const { data } = await context.$magento.api.categoryList(params, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -19,4 +19,4 @@ const factoryParams: UseCategoryFactoryParams<Category, any> = {
   },
 };
 
-export default useCategoryFactory<Category, any>(factoryParams);
+export default useCategoryFactory<Category, CategoryListQueryVariables>(factoryParams);

--- a/packages/composables/src/composables/useCategorySearch/index.ts
+++ b/packages/composables/src/composables/useCategorySearch/index.ts
@@ -1,15 +1,15 @@
 import {
   Context, Logger,
 } from '@vue-storefront/core';
-import { Category } from '@vue-storefront/magento-api';
+import { Category, CategorySearchQueryVariables } from '@vue-storefront/magento-api';
 import { UseCategorySearchFactory, useCategorySearchFactory } from '../../factories/useCategorySearchFactory';
 import { UseCategorySearch } from '../../types/composables';
 
-const factoryParams: UseCategorySearchFactory<Category> = {
+const factoryParams: UseCategorySearchFactory<Category, CategorySearchQueryVariables> = {
   search: async (context: Context, params): Promise<Category[]> => {
     Logger.debug('[Magento]: Search for category using', { params });
-
-    const { data } = await context.$magento.api.categorySearch({ filters: { name: { match: `${params.term}` } } });
+    const { filters, customQuery } = params;
+    const { data } = await context.$magento.api.categorySearch({ filters }, customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -17,6 +17,6 @@ const factoryParams: UseCategorySearchFactory<Category> = {
   },
 };
 
-const useCategorySearch: (cacheId?: string) => UseCategorySearch<Category> = useCategorySearchFactory<Category>(factoryParams);
+const useCategorySearch: (cacheId?: string) => UseCategorySearch<Category, CategorySearchQueryVariables> = useCategorySearchFactory<Category, CategorySearchQueryVariables>(factoryParams);
 
 export default useCategorySearch;

--- a/packages/composables/src/composables/useConfig/index.ts
+++ b/packages/composables/src/composables/useConfig/index.ts
@@ -4,8 +4,8 @@ import { useConfigFactory, UseConfigFactoryParams } from '../../factories/useCon
 import { UseConfig } from '../../types/composables';
 
 const factoryParams: UseConfigFactoryParams<StoreConfig> = {
-  loadConfig: async (context: Context) => {
-    const { data } = await context.$magento.api.storeConfig();
+  loadConfig: async (context: Context, params) => {
+    const { data } = await context.$magento.api.storeConfig(params.customQuery || {});
 
     return data.storeConfig || {};
   },
@@ -14,8 +14,3 @@ const factoryParams: UseConfigFactoryParams<StoreConfig> = {
 const useConfig: (cacheId?: string) => UseConfig<StoreConfig> = useConfigFactory<StoreConfig>(factoryParams);
 
 export default useConfig;
-
-
-
-
-

--- a/packages/composables/src/composables/useConfig/index.ts
+++ b/packages/composables/src/composables/useConfig/index.ts
@@ -5,7 +5,7 @@ import { UseConfig } from '../../types/composables';
 
 const factoryParams: UseConfigFactoryParams<StoreConfig> = {
   loadConfig: async (context: Context, params) => {
-    const { data } = await context.$magento.api.storeConfig(params.customQuery || {});
+    const { data } = await context.$magento.api.storeConfig(params?.customQuery || {});
 
     return data.storeConfig || {};
   },

--- a/packages/composables/src/composables/useContent/index.ts
+++ b/packages/composables/src/composables/useContent/index.ts
@@ -3,19 +3,19 @@ import { Page, CmsBlock } from '@vue-storefront/magento-api';
 import { useContentFactory, UseContentFactoryParams } from '../../factories/useContentFactory';
 
 const factoryParams: UseContentFactoryParams<Page, CmsBlock> = {
-  loadContent: async (context: Context, identifier: string) => {
-    Logger.debug('[Magento]: Load CMS Page content', { identifier });
+  loadContent: async (context: Context, params) => {
+    Logger.debug('[Magento]: Load CMS Page content', { params });
 
-    const { data } = await context.$magento.api.cmsPage(identifier);
+    const { data } = await context.$magento.api.cmsPage(params.identifier, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
     return data.cmsPage;
   },
-  loadBlocks: async (context: Context, identifiers: string[]) => {
-    Logger.debug('[Magento]: Load CMS Blocks content', { identifiers });
+  loadBlocks: async (context: Context, params) => {
+    Logger.debug('[Magento]: Load CMS Blocks content', { params });
 
-    const { data } = await context.$magento.api.cmsBlocks(identifiers);
+    const { data } = await context.$magento.api.cmsBlocks(params.identifiers, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useContent/index.ts
+++ b/packages/composables/src/composables/useContent/index.ts
@@ -6,7 +6,7 @@ const factoryParams: UseContentFactoryParams<Page, CmsBlock> = {
   loadContent: async (context: Context, params) => {
     Logger.debug('[Magento]: Load CMS Page content', { params });
 
-    const { data } = await context.$magento.api.cmsPage(params.identifier, params.customQuery || {});
+    const { data } = await context.$magento.api.cmsPage(params.identifier, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -15,7 +15,7 @@ const factoryParams: UseContentFactoryParams<Page, CmsBlock> = {
   loadBlocks: async (context: Context, params) => {
     Logger.debug('[Magento]: Load CMS Blocks content', { params });
 
-    const { data } = await context.$magento.api.cmsBlocks(params.identifiers, params.customQuery || {});
+    const { data } = await context.$magento.api.cmsBlocks(params.identifiers, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useCountrySearch/index.ts
+++ b/packages/composables/src/composables/useCountrySearch/index.ts
@@ -9,7 +9,7 @@ const factoryParams: UseCountryFactoryParams<Countries, Country> = {
   load: async (context: Context, params): Promise<Countries[]> => {
     Logger.debug('[Magento]: Load available countries on store');
 
-    const { data } = await context.$magento.api.countries(params.customQuery || {});
+    const { data } = await context.$magento.api.countries(params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -18,7 +18,7 @@ const factoryParams: UseCountryFactoryParams<Countries, Country> = {
   search: async (context: Context, params): Promise<Country> => {
     Logger.debug('[Magento]: Search country information based on', { params });
 
-    const { data } = await context.$magento.api.country(params.id, params.customQuery || {});
+    const { data } = await context.$magento.api.country(params.id, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useCountrySearch/index.ts
+++ b/packages/composables/src/composables/useCountrySearch/index.ts
@@ -6,10 +6,10 @@ import { UseCountryFactoryParams, useCountrySearchFactory } from '../../factorie
 import { UseCountrySearch } from '../../types/composables';
 
 const factoryParams: UseCountryFactoryParams<Countries, Country> = {
-  load: async (context: Context): Promise<Countries[]> => {
+  load: async (context: Context, params): Promise<Countries[]> => {
     Logger.debug('[Magento]: Load available countries on store');
 
-    const { data } = await context.$magento.api.countries();
+    const { data } = await context.$magento.api.countries(params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -18,7 +18,7 @@ const factoryParams: UseCountryFactoryParams<Countries, Country> = {
   search: async (context: Context, params): Promise<Country> => {
     Logger.debug('[Magento]: Search country information based on', { params });
 
-    const { data } = await context.$magento.api.country(params.id);
+    const { data } = await context.$magento.api.country(params.id, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useCurrency/index.ts
+++ b/packages/composables/src/composables/useCurrency/index.ts
@@ -4,14 +4,14 @@ import { useCurrencyFactory, UseCurrencyFactoryParams } from '../../factories/us
 import { UseCurrency } from '../../types/composables';
 
 const factoryParams: UseCurrencyFactoryParams<Currency, null> = {
-  load: async (context: Context): Promise<Currency> => {
-    const { data } = await context.$magento.api.currency();
+  load: async (context: Context, params): Promise<Currency> => {
+    const { data } = await context.$magento.api.currency(params.customQuery || {});
 
     return data.currency || {};
   },
 
-  change: (context: Context, currency) => {
-    context.$magento.config.state.setCurrency(currency);
+  change: (context: Context, params) => {
+    context.$magento.config.state.setCurrency(params.id);
   },
 };
 

--- a/packages/composables/src/composables/useCurrency/index.ts
+++ b/packages/composables/src/composables/useCurrency/index.ts
@@ -5,7 +5,7 @@ import { UseCurrency } from '../../types/composables';
 
 const factoryParams: UseCurrencyFactoryParams<Currency, null> = {
   load: async (context: Context, params): Promise<Currency> => {
-    const { data } = await context.$magento.api.currency(params.customQuery || {});
+    const { data } = await context.$magento.api.currency(params?.customQuery || {});
 
     return data.currency || {};
   },

--- a/packages/composables/src/composables/useExternalCheckout/index.ts
+++ b/packages/composables/src/composables/useExternalCheckout/index.ts
@@ -9,8 +9,8 @@ const factoryParams: UseExternalCheckoutFactoryParams = {
       cart: useCart(),
     };
   },
-  initializeCheckout: async (context: Context, baseUrl: string) => {
-    Logger.debug('[Magento]: Initialize external checkout', { baseUrl });
+  initializeCheckout: async (context: Context, params) => {
+    Logger.debug('[Magento]: Initialize external checkout', { params });
 
     const { externalCheckout, state } = context.$magento.config;
 
@@ -33,7 +33,7 @@ const factoryParams: UseExternalCheckoutFactoryParams = {
       return Promise.resolve('');
     }
 
-    return Promise.resolve(baseUrl);
+    return Promise.resolve(params.baseUrl);
   },
 };
 

--- a/packages/composables/src/composables/useFacet/index.ts
+++ b/packages/composables/src/composables/useFacet/index.ts
@@ -1,4 +1,5 @@
 import {
+  ComposableFunctionArgs,
   Context,
   FacetSearchResult, Logger,
   ProductsSearchParams,
@@ -58,7 +59,7 @@ const constructSortObject = (sortData: string) => {
 
 const factoryParams = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  search: async (context: Context, params: FacetSearchResult<any>) => {
+  search: async (context: Context, params: ComposableFunctionArgs<FacetSearchResult<any>>) => {
     Logger.debug('[Magento] Load product facets', { params });
 
     const itemsPerPage = (params.input.itemsPerPage) ? params.input.itemsPerPage : 20;
@@ -93,7 +94,7 @@ const factoryParams = {
       currentPage: productParams.page,
     };
 
-    const { data } = await context.$magento.api.products(productSearchParams);
+    const { data } = await context.$magento.api.products(productSearchParams, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useFacet/index.ts
+++ b/packages/composables/src/composables/useFacet/index.ts
@@ -94,7 +94,7 @@ const factoryParams = {
       currentPage: productParams.page,
     };
 
-    const { data } = await context.$magento.api.products(productSearchParams, params.customQuery || {});
+    const { data } = await context.$magento.api.products(productSearchParams, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useGetShippingMethods/index.ts
+++ b/packages/composables/src/composables/useGetShippingMethods/index.ts
@@ -11,7 +11,7 @@ const factoryParams: UseGetShippingMethodsFactory<ShippingMethod> = {
     const isGuest = params.cartId;
 
     if (isGuest) {
-      const { data } = await context.$magento.api.getAvailableShippingMethods({ cartId: params.cartId }, params.customQuery || {});
+      const { data } = await context.$magento.api.getAvailableShippingMethods({ cartId: params.cartId }, params?.customQuery || {});
 
       Logger.debug('[Result]:', { data });
 
@@ -20,7 +20,7 @@ const factoryParams: UseGetShippingMethodsFactory<ShippingMethod> = {
       return hasAddresses ? data.cart.shipping_addresses[0].available_shipping_methods : [];
     }
 
-    const { data } = await context.$magento.api.getAvailableCustomerShippingMethods(params.customQuery || {});
+    const { data } = await context.$magento.api.getAvailableCustomerShippingMethods(params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useGetShippingMethods/index.ts
+++ b/packages/composables/src/composables/useGetShippingMethods/index.ts
@@ -11,7 +11,7 @@ const factoryParams: UseGetShippingMethodsFactory<ShippingMethod> = {
     const isGuest = params.cartId;
 
     if (isGuest) {
-      const { data } = await context.$magento.api.getAvailableShippingMethods({ cartId: params.cartId });
+      const { data } = await context.$magento.api.getAvailableShippingMethods({ cartId: params.cartId }, params.customQuery || {});
 
       Logger.debug('[Result]:', { data });
 
@@ -20,7 +20,7 @@ const factoryParams: UseGetShippingMethodsFactory<ShippingMethod> = {
       return hasAddresses ? data.cart.shipping_addresses[0].available_shipping_methods : [];
     }
 
-    const { data } = await context.$magento.api.getAvailableCustomerShippingMethods();
+    const { data } = await context.$magento.api.getAvailableCustomerShippingMethods(params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useGuestUser/index.ts
+++ b/packages/composables/src/composables/useGuestUser/index.ts
@@ -19,7 +19,7 @@ const factoryParams: UseGuestUserFactoryParams<any, SetGuestEmailOnCartInput> = 
 
     await context.$magento.api.setGuestEmailOnCart({
       ...emailOnCartInput,
-    }, params.customQuery || {});
+    }, params?.customQuery || {});
   },
 };
 

--- a/packages/composables/src/composables/useGuestUser/index.ts
+++ b/packages/composables/src/composables/useGuestUser/index.ts
@@ -3,7 +3,7 @@ import { Logger } from '@vue-storefront/core';
 import { useGuestUserFactory, UseGuestUserFactoryParams } from '../../factories/useGuestUserFactory';
 import useCart from '../useCart';
 
-const factoryParams: UseGuestUserFactoryParams<any, any> = {
+const factoryParams: UseGuestUserFactoryParams<any, SetGuestEmailOnCartInput> = {
   provide() {
     return {
       cart: useCart(),
@@ -17,8 +17,10 @@ const factoryParams: UseGuestUserFactoryParams<any, any> = {
       cart_id: context.cart.cart.value.id,
     };
 
-    await context.$magento.api.setGuestEmailOnCart(emailOnCartInput);
+    await context.$magento.api.setGuestEmailOnCart({
+      ...emailOnCartInput,
+    }, params.customQuery || {});
   },
 };
 
-export default useGuestUserFactory<any, any>(factoryParams);
+export default useGuestUserFactory<any, SetGuestEmailOnCartInput & { email:string;password:string }>(factoryParams);

--- a/packages/composables/src/composables/useNewsletter/index.ts
+++ b/packages/composables/src/composables/useNewsletter/index.ts
@@ -5,18 +5,21 @@ import {
 import useUser from '../useUser';
 import { useNewsletterFactory, UseNewsletterFactoryParams } from '../../factories/useNewsletterFactory';
 
-const factoryParams: UseNewsletterFactoryParams<any, any> = {
+const factoryParams: UseNewsletterFactoryParams<any, string> = {
   provide() {
     return {
       user: useUser(),
     };
   },
-  updateSubscription: async (context: Context, { email }) => {
-    Logger.debug('[Magento]: Update user newsletter subscription', { email });
+  updateSubscription: async (context: Context, params) => {
+    Logger.debug('[Magento]: Update user newsletter subscription', { params });
 
-    const { data } = await context.$magento.api.subscribeEmailToNewsletter({
-      email,
-    });
+    const { data } = await context.$magento.api.subscribeEmailToNewsletter(
+      {
+        email: params.email,
+      },
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 
@@ -24,4 +27,4 @@ const factoryParams: UseNewsletterFactoryParams<any, any> = {
   },
 };
 
-export default useNewsletterFactory<any, any>(factoryParams);
+export default useNewsletterFactory<any, string>(factoryParams);

--- a/packages/composables/src/composables/useNewsletter/index.ts
+++ b/packages/composables/src/composables/useNewsletter/index.ts
@@ -18,7 +18,7 @@ const factoryParams: UseNewsletterFactoryParams<any, string> = {
       {
         email: params.email,
       },
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });

--- a/packages/composables/src/composables/usePaymentProvider/index.ts
+++ b/packages/composables/src/composables/usePaymentProvider/index.ts
@@ -3,12 +3,13 @@ import {
   Logger,
 } from '@vue-storefront/core';
 import {
+  PaymentMethodInput,
   SetPaymentMethodOnCartInputs,
 } from '@vue-storefront/magento-api';
 import useCart from '../useCart';
 import { usePaymentProviderFactory, UsePaymentProviderParams } from '../../factories/usePaymentProviderFactory';
 
-const factoryParams: UsePaymentProviderParams<any, any> = {
+const factoryParams: UsePaymentProviderParams<any, PaymentMethodInput> = {
   provide() {
     return {
       cart: useCart(),
@@ -29,20 +30,20 @@ const factoryParams: UsePaymentProviderParams<any, any> = {
       .available_payment_methods;
   },
 
-  save: async (context: Context, { paymentMethod }) => {
-    Logger.debug('[Magento] savePaymentProvider', { paymentMethod });
+  save: async (context: Context, params) => {
+    Logger.debug('[Magento] savePaymentProvider', { params });
 
     const paymentMethodParams: SetPaymentMethodOnCartInputs = {
       cart_id: context.cart.cart.value.id,
       payment_method: {
-        ...paymentMethod,
+        ...params.paymentMethod,
       },
     };
 
     const { data } = await context
       .$magento
       .api
-      .setPaymentMethodOnCart(paymentMethodParams);
+      .setPaymentMethodOnCart(paymentMethodParams, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -53,4 +54,4 @@ const factoryParams: UsePaymentProviderParams<any, any> = {
   },
 };
 
-export default usePaymentProviderFactory<any, any>(factoryParams);
+export default usePaymentProviderFactory<any, PaymentMethodInput>(factoryParams);

--- a/packages/composables/src/composables/usePaymentProvider/index.ts
+++ b/packages/composables/src/composables/usePaymentProvider/index.ts
@@ -43,7 +43,7 @@ const factoryParams: UsePaymentProviderParams<any, PaymentMethodInput> = {
     const { data } = await context
       .$magento
       .api
-      .setPaymentMethodOnCart(paymentMethodParams, params.customQuery || {});
+      .setPaymentMethodOnCart(paymentMethodParams, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useProduct/index.ts
+++ b/packages/composables/src/composables/useProduct/index.ts
@@ -1,7 +1,7 @@
 import {
   ComposableFunctionArgs,
   Context,
-  CustomQuery, Logger,
+  Logger,
   ProductsSearchParams,
   UseProduct,
   useProductFactory,
@@ -22,7 +22,10 @@ ProductsSearchParams> = {
       queryType,
       customQuery,
       ...searchParams
-    } = params;
+    } = {
+      ...params,
+      customQuery: params?.customQuery || {},
+    };
 
     switch (queryType) {
       case ProductsQueryType.Detail:

--- a/packages/composables/src/composables/useProduct/index.ts
+++ b/packages/composables/src/composables/useProduct/index.ts
@@ -1,4 +1,5 @@
 import {
+  ComposableFunctionArgs,
   Context,
   CustomQuery, Logger,
   ProductsSearchParams,
@@ -11,11 +12,10 @@ import { Scalars } from '@vue-storefront/magento-api/lib/types/GraphQL';
 
 const factoryParams: UseProductFactoryParams<ProductsListQuery['products'],
 ProductsSearchParams> = {
-  productsSearch: async (context: Context, params: GetProductSearchParams & {
+  productsSearch: async (context: Context, params: ComposableFunctionArgs<GetProductSearchParams & {
     queryType: ProductsQueryType;
-    customQuery?: CustomQuery;
     configurations?: Scalars['ID']
-  }) => {
+  }>) => {
     Logger.debug('[Magento]: Load product based on ', { params });
 
     const {

--- a/packages/composables/src/composables/useRelatedProducts/index.ts
+++ b/packages/composables/src/composables/useRelatedProducts/index.ts
@@ -1,6 +1,7 @@
 import {
+  ComposableFunctionArgs,
   Context,
-  CustomQuery, Logger,
+  Logger,
   ProductsSearchParams,
 } from '@vue-storefront/core';
 import {
@@ -14,10 +15,10 @@ import {
 } from '../../factories/useRelatedProductsFactory';
 
 const factoryParams: UseRelatedProductsFactoryParams<RelatedProductQuery['products']['items'][0]['related_products'], ProductsSearchParams> = {
-  productsSearch: async (context: Context,
-    params: GetProductSearchParams & {
-      customQuery?: CustomQuery;
-    }) => {
+  productsSearch: async (
+    context: Context,
+    params: ComposableFunctionArgs<GetProductSearchParams>,
+  ) => {
     Logger.debug('[Magento] Load related products based on ', { params });
 
     const {

--- a/packages/composables/src/composables/useReview/index.ts
+++ b/packages/composables/src/composables/useReview/index.ts
@@ -20,26 +20,34 @@ ProductReviewRatingMetadata> = {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   searchReviews: async (context: Context, params?: ComposableFunctionArgs<GetProductSearchParams>) => {
     Logger.debug('[Magento] search review params input:', JSON.stringify(params, null, 2));
+    const {
+      customQuery,
+      ...input
+    } = params;
 
-    const { data } = await context.$magento.api.productReview(params as GetProductSearchParams);
+    const { data } = await context.$magento.api.productReview(input as GetProductSearchParams, customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
     return data.products.items;
   },
-  addReview: async (context: Context, params: CreateProductReviewInput) => {
+  addReview: async (context: Context, params: ComposableFunctionArgs<CreateProductReviewInput>) => {
     Logger.debug('[Magento] add review params input:', JSON.stringify(params, null, 2));
+    const {
+      customQuery,
+      ...input
+    } = params;
 
-    const { data } = await context.$magento.api.createProductReview(params);
+    const { data } = await context.$magento.api.createProductReview(input, customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
     return data.createProductReview.review;
   },
-  loadReviewMetadata: async (context: Context) => {
+  loadReviewMetadata: async (context: Context, params) => {
     Logger.debug('[Magento] load review metadata');
 
-    const { data } = await context.$magento.api.productReviewRatingsMetadata();
+    const { data } = await context.$magento.api.productReviewRatingsMetadata(params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -50,8 +58,12 @@ ProductReviewRatingMetadata> = {
     params?: ComposableFunctionArgs<CustomerProductReviewParams>,
   ) => {
     Logger.debug('[Magento] load customer review based on:', { params });
+    const {
+      customQuery,
+      ...input
+    } = params;
 
-    const { data } = await context.$magento.api.customerProductReview(params);
+    const { data } = await context.$magento.api.customerProductReview(input, customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useReview/index.ts
+++ b/packages/composables/src/composables/useReview/index.ts
@@ -47,7 +47,7 @@ ProductReviewRatingMetadata> = {
   loadReviewMetadata: async (context: Context, params) => {
     Logger.debug('[Magento] load review metadata');
 
-    const { data } = await context.$magento.api.productReviewRatingsMetadata(params.customQuery || {});
+    const { data } = await context.$magento.api.productReviewRatingsMetadata(params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useShipping/index.ts
+++ b/packages/composables/src/composables/useShipping/index.ts
@@ -29,16 +29,18 @@ const factoryParams: UseShippingParams<any, any> = {
   },
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  save: async (context: Context, saveParams) => {
-    Logger.debug('[Magento] save user shipping address', { saveParams });
+  save: async (context: Context, params) => {
+    Logger.debug('[Magento] save user shipping address', { params });
 
     const { id } = context.cart.cart.value;
 
     const {
       apartment,
+      neighborhood,
+      extra,
       customerAddressId,
       ...address
-    } = saveParams.shippingDetails;
+    } = params.shippingDetails;
 
     const shippingData = customerAddressId
       ? ({
@@ -47,7 +49,7 @@ const factoryParams: UseShippingParams<any, any> = {
       : ({
         address: {
           ...address,
-          street: [address.street, apartment],
+          street: [address.street, apartment, neighborhood, extra],
         },
       });
 
@@ -63,7 +65,7 @@ const factoryParams: UseShippingParams<any, any> = {
     const { data } = await context
       .$magento
       .api
-      .setShippingAddressesOnCart(shippingAddressInput);
+      .setShippingAddressesOnCart(shippingAddressInput, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useShipping/index.ts
+++ b/packages/composables/src/composables/useShipping/index.ts
@@ -65,7 +65,7 @@ const factoryParams: UseShippingParams<any, any> = {
     const { data } = await context
       .$magento
       .api
-      .setShippingAddressesOnCart(shippingAddressInput, params.customQuery || {});
+      .setShippingAddressesOnCart(shippingAddressInput, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useShippingProvider/index.ts
+++ b/packages/composables/src/composables/useShippingProvider/index.ts
@@ -15,11 +15,11 @@ const factoryParams: UseShippingProviderParams<any, ShippingMethodInput> = {
       cart: useCart(),
     };
   },
-  load: async (context: Context, { customQuery }) => {
-    Logger.debug('[Magento] loadShippingProvider', { customQuery });
+  load: async (context: Context, params) => {
+    Logger.debug('[Magento] loadShippingProvider', { params });
 
     if (!context.cart.cart?.value?.shipping_addresses[0]?.selected_shipping_method) {
-      await context.cart.load({ customQuery });
+      await context.cart.load({ customQuery: params?.customQuery || {} });
     }
 
     return context
@@ -38,7 +38,7 @@ const factoryParams: UseShippingProviderParams<any, ShippingMethodInput> = {
       }],
     };
 
-    const { data } = await context.$magento.api.setShippingMethodsOnCart(shippingMethodParams, params.customQuery || {});
+    const { data } = await context.$magento.api.setShippingMethodsOnCart(shippingMethodParams, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useShippingProvider/index.ts
+++ b/packages/composables/src/composables/useShippingProvider/index.ts
@@ -5,11 +5,11 @@ import {
   UseShippingProviderParams,
 } from '@vue-storefront/core';
 import {
-  SetShippingMethodsOnCartInput,
+  SetShippingMethodsOnCartInput, ShippingMethodInput,
 } from '@vue-storefront/magento-api';
 import useCart from '../useCart';
 
-const factoryParams: UseShippingProviderParams<any, any> = {
+const factoryParams: UseShippingProviderParams<any, ShippingMethodInput> = {
   provide() {
     return {
       cart: useCart(),
@@ -28,17 +28,17 @@ const factoryParams: UseShippingProviderParams<any, any> = {
       .value?.shipping_addresses[0]?.selected_shipping_method;
   },
 
-  save: async (context: Context, { shippingMethod }) => {
-    Logger.debug('[Magento] saveShippingProvider', { shippingMethod });
+  save: async (context: Context, params) => {
+    Logger.debug('[Magento] saveShippingProvider', { params });
 
     const shippingMethodParams: SetShippingMethodsOnCartInput = {
       cart_id: context.cart.cart.value.id,
       shipping_methods: [{
-        ...shippingMethod,
+        ...params.shippingMethod,
       }],
     };
 
-    const { data } = await context.$magento.api.setShippingMethodsOnCart(shippingMethodParams);
+    const { data } = await context.$magento.api.setShippingMethodsOnCart(shippingMethodParams, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -53,4 +53,4 @@ const factoryParams: UseShippingProviderParams<any, any> = {
   },
 };
 
-export default useShippingProviderFactory<any, any>(factoryParams);
+export default useShippingProviderFactory<any, ShippingMethodInput>(factoryParams);

--- a/packages/composables/src/composables/useStore/index.ts
+++ b/packages/composables/src/composables/useStore/index.ts
@@ -12,7 +12,7 @@ const factoryParams: UseStoreFactoryParams<AvailableStores, StoreConfig> = {
     };
   },
   load: async (context: Context, params): Promise<AvailableStores> => {
-    const { data } = await context.$magento.api.availableStores(params.customQuery || {});
+    const { data } = await context.$magento.api.availableStores(params?.customQuery || {});
 
     return data.availableStores || [];
   },

--- a/packages/composables/src/composables/useStore/index.ts
+++ b/packages/composables/src/composables/useStore/index.ts
@@ -11,8 +11,8 @@ const factoryParams: UseStoreFactoryParams<AvailableStores, StoreConfig> = {
       cart: useCart(),
     };
   },
-  load: async (context: Context): Promise<AvailableStores> => {
-    const { data } = await context.$magento.api.availableStores();
+  load: async (context: Context, params): Promise<AvailableStores> => {
+    const { data } = await context.$magento.api.availableStores(params.customQuery || {});
 
     return data.availableStores || [];
   },
@@ -27,6 +27,6 @@ const factoryParams: UseStoreFactoryParams<AvailableStores, StoreConfig> = {
   },
 };
 
-const useStore: () => UseStore<AvailableStores, StoreConfig> = useStoreFactory<AvailableStores>(factoryParams);
+const useStore: () => UseStore<AvailableStores, StoreConfig> = useStoreFactory<AvailableStores, StoreConfig>(factoryParams);
 
 export default useStore;

--- a/packages/composables/src/composables/useUpsellProducts/index.ts
+++ b/packages/composables/src/composables/useUpsellProducts/index.ts
@@ -24,7 +24,10 @@ const factoryParams: UseUpsellProductsFactoryParams<UpsellProductsQuery['product
     const {
       customQuery,
       ...searchParams
-    } = params;
+    } = {
+      ...params,
+      customQuery: params?.customQuery || {},
+    };
 
     const { data } = await context
       .$magento

--- a/packages/composables/src/composables/useUpsellProducts/index.ts
+++ b/packages/composables/src/composables/useUpsellProducts/index.ts
@@ -1,6 +1,7 @@
 import {
+  ComposableFunctionArgs,
   Context,
-  CustomQuery, Logger,
+  Logger,
   ProductsSearchParams,
 } from '@vue-storefront/core';
 import {
@@ -14,10 +15,10 @@ import {
 import { UseUpsellProducts } from '../../types/composables';
 
 const factoryParams: UseUpsellProductsFactoryParams<UpsellProductsQuery['products']['items'][0]['upsell_products'], ProductsSearchParams> = {
-  productsSearch: async (context: Context,
-    params: GetProductSearchParams & {
-      customQuery?: CustomQuery;
-    }) => {
+  productsSearch: async (
+    context: Context,
+    params: ComposableFunctionArgs<GetProductSearchParams>,
+  ) => {
     Logger.debug('[Magento] Find upsell products based on ', { params });
 
     const {

--- a/packages/composables/src/composables/useUrlResolver/index.ts
+++ b/packages/composables/src/composables/useUrlResolver/index.ts
@@ -8,7 +8,7 @@ const factoryParams: UseUrlResolverFactoryParams<Route> = {
     Logger.debug('[Magento] Find information based on URL', { params });
     const clearUrl = params.url.replace(/\/[cp|]\//gi, '');
 
-    const { data } = await context.$magento.api.urlResolver(clearUrl, params.customQuery || {});
+    const { data } = await context.$magento.api.urlResolver(clearUrl, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUrlResolver/index.ts
+++ b/packages/composables/src/composables/useUrlResolver/index.ts
@@ -4,11 +4,11 @@ import { useUrlResolverFactory, UseUrlResolverFactoryParams } from '../../factor
 import { UseUrlResolver } from '../../types/composables';
 
 const factoryParams: UseUrlResolverFactoryParams<Route> = {
-  search: async (context: Context, url: string) => {
-    Logger.debug('[Magento] Find information based on URL', { url });
-    const clearUrl = url.replace(/\/[cp|]\//gi, '');
+  search: async (context: Context, params) => {
+    Logger.debug('[Magento] Find information based on URL', { params });
+    const clearUrl = params.url.replace(/\/[cp|]\//gi, '');
 
-    const { data } = await context.$magento.api.urlResolver(clearUrl);
+    const { data } = await context.$magento.api.urlResolver(clearUrl, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUser/index.ts
+++ b/packages/composables/src/composables/useUser/index.ts
@@ -26,7 +26,7 @@ CustomerCreateInput
       return null;
     }
     try {
-      const { data } = await context.$magento.api.customer(params.customQuery || {});
+      const { data } = await context.$magento.api.customer(params?.customQuery || {});
 
       Logger.debug('[Result]:', { data });
 
@@ -60,10 +60,10 @@ CustomerCreateInput
       await context.$magento.api.updateCustomerEmail({
         email,
         password,
-      }, params.customQuery || {});
+      }, params?.customQuery || {});
     }
 
-    const { data } = await context.$magento.api.updateCustomer(userData, params.customQuery || {});
+    const { data } = await context.$magento.api.updateCustomer(userData, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -74,7 +74,7 @@ CustomerCreateInput
 
     const { data, errors } = await context.$magento.api.createCustomer(
       { email, password, ...baseData },
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });
@@ -99,7 +99,7 @@ CustomerCreateInput
         email: params.username,
         password: params.password,
       },
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });
@@ -116,7 +116,7 @@ CustomerCreateInput
 
     // merge existing cart with customer cart
     const currentCartId = apiState.getCartId();
-    const cart = await context.$magento.api.customerCart(params.customQuery || {});
+    const cart = await context.$magento.api.customerCart(params?.customQuery || {});
     const newCartId = cart.data.customerCart.id;
 
     if (newCartId && currentCartId && currentCartId !== newCartId) {
@@ -125,7 +125,7 @@ CustomerCreateInput
           sourceCartId: currentCartId,
           destinationCartId: newCartId,
         },
-        params.customQuery || {},
+        params?.customQuery || {},
       );
 
       context.cart.setCart(dataMergeCart.mergeCarts);
@@ -135,13 +135,13 @@ CustomerCreateInput
       context.cart.setCart(cart.data.customerCart);
     }
 
-    await context.$magento.api.wishlist({}, params.customQuery || {});
+    await context.$magento.api.wishlist({}, params?.customQuery || {});
 
     return factoryParams.load(context);
   },
   changePassword: async (context: Context, params) => {
     Logger.debug('[Magento] changing user password');
-    const { data, errors } = await context.$magento.api.changeCustomerPassword(params, params.customQuery || {});
+    const { data, errors } = await context.$magento.api.changeCustomerPassword(params, params?.customQuery || {});
 
     if (errors) {
       Logger.error(errors);

--- a/packages/composables/src/composables/useUserBilling/index.ts
+++ b/packages/composables/src/composables/useUserBilling/index.ts
@@ -18,7 +18,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   addAddress: async (context: Context, params?) => {
     Logger.debug('[Magento]: add billing address', { params });
 
-    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(params));
+    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(params), params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -28,7 +28,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   deleteAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] delete billing address', { params });
 
-    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id);
+    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -38,7 +38,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   updateAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] update billing address', { params });
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params));
+    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -59,7 +59,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   setDefaultAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] setDefaultAddress');
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params));
+    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUserBilling/index.ts
+++ b/packages/composables/src/composables/useUserBilling/index.ts
@@ -18,7 +18,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   addAddress: async (context: Context, params?) => {
     Logger.debug('[Magento]: add billing address', { params });
 
-    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(params), params.customQuery || {});
+    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(params), params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -28,7 +28,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   deleteAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] delete billing address', { params });
 
-    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id, params.customQuery || {});
+    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -38,7 +38,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   updateAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] update billing address', { params });
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params.customQuery || {});
+    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -59,7 +59,7 @@ const factoryParams: UseUserBillingFactoryParams<any, any> = {
   setDefaultAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] setDefaultAddress');
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params.customQuery || {});
+    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params), params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUserOrder/index.ts
+++ b/packages/composables/src/composables/useUserOrder/index.ts
@@ -22,7 +22,7 @@ const factoryParams: UseUserOrderFactoryParams<any, GetOrdersSearchParams> = {
       await context.user.load();
     }
 
-    const { data } = await context.$magento.api.customerOrders(params, params.customQuery || {});
+    const { data } = await context.$magento.api.customerOrders(params, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUserOrder/index.ts
+++ b/packages/composables/src/composables/useUserOrder/index.ts
@@ -5,23 +5,24 @@ import {
   useUserOrderFactory,
   UseUserOrderFactoryParams,
 } from '@vue-storefront/core';
+import { GetOrdersSearchParams } from '@vue-storefront/magento-api';
 import useUser from '../useUser';
 
-const factoryParams: UseUserOrderFactoryParams<any, any> = {
+const factoryParams: UseUserOrderFactoryParams<any, GetOrdersSearchParams> = {
   provide() {
     return {
       user: useUser(),
     };
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  searchOrders: async (context: Context, param) => {
-    Logger.debug('[Magento] search user orders', { param });
+  searchOrders: async (context: Context, params) => {
+    Logger.debug('[Magento] search user orders', { params });
 
     if (!context.user.user?.value?.id) {
       await context.user.load();
     }
 
-    const { data } = await context.$magento.api.customerOrders(param);
+    const { data } = await context.$magento.api.customerOrders(params, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 
@@ -29,4 +30,4 @@ const factoryParams: UseUserOrderFactoryParams<any, any> = {
   },
 };
 
-export default useUserOrderFactory<any, any>(factoryParams);
+export default useUserOrderFactory<any, GetOrdersSearchParams>(factoryParams);

--- a/packages/composables/src/composables/useUserShipping/index.ts
+++ b/packages/composables/src/composables/useUserShipping/index.ts
@@ -17,7 +17,10 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
   addAddress: async (context: Context, params?) => {
     Logger.debug('[Magento]: add shipping address', { params });
 
-    const { data } = await context.$magento.api.createCustomerAddress(transformUserCreateAddressInput(params));
+    const { data } = await context.$magento.api.createCustomerAddress(
+      transformUserCreateAddressInput(params),
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 
@@ -26,7 +29,10 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
 
   deleteAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] delete shipping address', { params });
-    const { data } = await context.$magento.api.deleteCustomerAddress(params.address.id);
+    const { data } = await context.$magento.api.deleteCustomerAddress(
+      params.address.id,
+      params.customQuery || {},
+    );
 
     return data.deleteCustomerAddress;
   },
@@ -34,7 +40,10 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
   updateAddress: async (context: Context, params?) => {
     Logger.debug('[Magento] update shipping address', { params });
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params));
+    const { data } = await context.$magento.api.updateCustomerAddress(
+      transformUserUpdateAddressInput(params),
+      params.customQuery || {},
+    );
 
     return data.updateCustomerAddress;
   },
@@ -53,7 +62,10 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
   setDefaultAddress: async (context: Context, params) => {
     Logger.debug('[Magento] set default shipping address');
 
-    const { data } = await context.$magento.api.updateCustomerAddress(transformUserUpdateAddressInput(params));
+    const { data } = await context.$magento.api.updateCustomerAddress(
+      transformUserUpdateAddressInput(params),
+      params.customQuery || {},
+    );
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useUserShipping/index.ts
+++ b/packages/composables/src/composables/useUserShipping/index.ts
@@ -19,7 +19,7 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
 
     const { data } = await context.$magento.api.createCustomerAddress(
       transformUserCreateAddressInput(params),
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });
@@ -31,7 +31,7 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
     Logger.debug('[Magento] delete shipping address', { params });
     const { data } = await context.$magento.api.deleteCustomerAddress(
       params.address.id,
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     return data.deleteCustomerAddress;
@@ -42,7 +42,7 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
 
     const { data } = await context.$magento.api.updateCustomerAddress(
       transformUserUpdateAddressInput(params),
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     return data.updateCustomerAddress;
@@ -64,7 +64,7 @@ const factoryParams: UseUserShippingFactoryParams<any, any> = {
 
     const { data } = await context.$magento.api.updateCustomerAddress(
       transformUserUpdateAddressInput(params),
-      params.customQuery || {},
+      params?.customQuery || {},
     );
 
     Logger.debug('[Result]:', { data });

--- a/packages/composables/src/composables/useWishlist/index.ts
+++ b/packages/composables/src/composables/useWishlist/index.ts
@@ -64,7 +64,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             sku: product.sku,
             quantity: 1,
           }],
-        }, params.customQuery || {});
+        }, params?.customQuery || {});
 
         Logger.debug('[Result]:', { data });
 
@@ -77,7 +77,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             quantity: 1,
             parent_sku: product.sku,
           }],
-        }, params.customQuery || {});
+        }, params?.customQuery || {});
 
         Logger.debug('[Result]:', { data: configurableProductData });
 
@@ -90,7 +90,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             quantity: 1,
             entered_options: product.bundle_options ? [...product.bundle_options] : [],
           }],
-        }, params.customQuery || {});
+        }, params?.customQuery || {});
 
         Logger.debug('[Result]:', { data: bundleProductData });
 
@@ -113,7 +113,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
     const { data } = await context.$magento.api.removeProductsFromWishlist({
       id: '0',
       items: [itemOnWishlist.id],
-    }, params.customQuery || {});
+    }, params?.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/composables/useWishlist/index.ts
+++ b/packages/composables/src/composables/useWishlist/index.ts
@@ -21,7 +21,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
     const apiState = context.$magento.config.state;
 
     if (apiState.getCustomerToken()) {
-      const { data } = await context.$magento.api.wishlist(params?.searchParams, params?.customQuery);
+      const { data } = await context.$magento.api.wishlist(params?.searchParams, params?.customQuery || {});
 
       Logger.debug('[Result]:', { data });
 
@@ -64,7 +64,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             sku: product.sku,
             quantity: 1,
           }],
-        });
+        }, params.customQuery || {});
 
         Logger.debug('[Result]:', { data });
 
@@ -77,7 +77,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             quantity: 1,
             parent_sku: product.sku,
           }],
-        });
+        }, params.customQuery || {});
 
         Logger.debug('[Result]:', { data: configurableProductData });
 
@@ -90,7 +90,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
             quantity: 1,
             entered_options: product.bundle_options ? [...product.bundle_options] : [],
           }],
-        });
+        }, params.customQuery || {});
 
         Logger.debug('[Result]:', { data: bundleProductData });
 
@@ -113,7 +113,7 @@ const factoryParams: UseWishlistFactoryParams<any, any, any> = {
     const { data } = await context.$magento.api.removeProductsFromWishlist({
       id: '0',
       items: [itemOnWishlist.id],
-    });
+    }, params.customQuery || {});
 
     Logger.debug('[Result]:', { data });
 

--- a/packages/composables/src/factories/useCartFactory.ts
+++ b/packages/composables/src/factories/useCartFactory.ts
@@ -1,29 +1,28 @@
 import {
-  CustomQuery, UseCart, Context, FactoryParams, UseCartErrors, PlatformApi, sharedRef, Logger, configureFactoryParams,
+  CustomQuery, UseCart, Context, FactoryParams, UseCartErrors, PlatformApi, sharedRef, Logger, configureFactoryParams, ComposableFunctionArgs,
 } from '@vue-storefront/core';
 import { computed, Ref } from '@vue/composition-api';
 
 export interface UseCartFactoryParams<CART, CART_ITEM, PRODUCT, API extends PlatformApi = any> extends FactoryParams<API> {
-  load: (context: Context, params: { customQuery?: any; realCart?: boolean; }) => Promise<CART>;
+  load: (context: Context, params: ComposableFunctionArgs<{ realCart?: boolean; }>) => Promise<CART>;
   addItem: (
     context: Context,
-    params: {
+    params: ComposableFunctionArgs<{
       currentCart: CART;
       product: PRODUCT;
       quantity: any;
-      customQuery?: CustomQuery;
-    }
+    }>
   ) => Promise<CART>;
-  removeItem: (context: Context, params: { currentCart: CART; product: CART_ITEM; customQuery?: CustomQuery }) => Promise<CART>;
+  removeItem: (context: Context, params: ComposableFunctionArgs<{ currentCart: CART; product: CART_ITEM; }>) => Promise<CART>;
   updateItemQty: (
     context: Context,
-    params: { currentCart: CART; product: CART_ITEM; quantity: number; customQuery?: CustomQuery }
+    params: ComposableFunctionArgs<{ currentCart: CART; product: CART_ITEM; quantity: number; }>
   ) => Promise<CART>;
   clear: (context: Context, params: { currentCart: CART }) => Promise<CART>;
-  applyCoupon: (context: Context, params: { currentCart: CART; couponCode: string; customQuery?: CustomQuery }) => Promise<{ updatedCart: CART }>;
+  applyCoupon: (context: Context, params: ComposableFunctionArgs<{ currentCart: CART; couponCode: string; }>) => Promise<{ updatedCart: CART }>;
   removeCoupon: (
     context: Context,
-    params: { currentCart: CART; couponCode: string; customQuery?: CustomQuery }
+    params: ComposableFunctionArgs<{ currentCart: CART; couponCode: string; }>
   ) => Promise<{ updatedCart: CART }>;
   isInCart: (context: Context, params: { currentCart: CART; product: PRODUCT }) => boolean;
 }

--- a/packages/composables/src/factories/useCategorySearchFactory.ts
+++ b/packages/composables/src/factories/useCategorySearchFactory.ts
@@ -9,14 +9,14 @@ import {
 import { ComposableFunctionArgs, PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseCategorySearch, UseCategorySearchErrors } from '../types/composables';
 
-export interface UseCategorySearchFactory<CATEGORY, API extends PlatformApi = any> extends FactoryParams<API> {
-  search: (context: Context, params: ComposableFunctionArgs<{ term: string }>) => Promise<CATEGORY[]>;
+export interface UseCategorySearchFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends PlatformApi = any> extends FactoryParams<API> {
+  search: (context: Context, params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>) => Promise<CATEGORY[]>;
 }
 
-export function useCategorySearchFactory<CATEGORY, API extends PlatformApi = any>(
-  factoryParams: UseCategorySearchFactory<CATEGORY, API>,
+export function useCategorySearchFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends PlatformApi = any>(
+  factoryParams: UseCategorySearchFactory<CATEGORY, CATEGORY_SEARCH_PARAMS, API>,
 ) {
-  return function useCategorySearch(id: string = ''): UseCategorySearch<CATEGORY, API> {
+  return function useCategorySearch(id: string = ''): UseCategorySearch<CATEGORY, CATEGORY_SEARCH_PARAMS, API> {
     const ssrKey = id || 'useCategorySearch';
     // @ts-ignore
     const result = sharedRef<CATEGORY>([], `${ssrKey}-result`);
@@ -28,7 +28,7 @@ export function useCategorySearchFactory<CATEGORY, API extends PlatformApi = any
     const _factoryParams = configureFactoryParams(factoryParams);
 
     // eslint-disable-next-line consistent-return
-    const search = async (params: ComposableFunctionArgs<{ term: string }>): Promise<CATEGORY[]> => {
+    const search = async (params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>): Promise<CATEGORY[]> => {
       Logger.debug(`useCategorySearch/${ssrKey}/search`);
 
       try {

--- a/packages/composables/src/factories/useConfigFactory.ts
+++ b/packages/composables/src/factories/useConfigFactory.ts
@@ -3,13 +3,13 @@ import {
   Context,
   sharedRef,
   Logger,
-  configureFactoryParams, FactoryParams,
+  configureFactoryParams, FactoryParams, ComposableFunctionArgs,
 } from '@vue-storefront/core';
 import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseConfig } from '../types/composables';
 
 export interface UseConfigFactoryParams<CONFIG, API extends PlatformApi = any> extends FactoryParams<API>{
-  loadConfig: (context: Context) => Promise<CONFIG>;
+  loadConfig: (context: Context, params?: ComposableFunctionArgs<{}>) => Promise<CONFIG>;
 }
 
 export function useConfigFactory<CONFIG, API extends PlatformApi = any>(factoryParams: UseConfigFactoryParams<CONFIG, API>) {
@@ -21,11 +21,11 @@ export function useConfigFactory<CONFIG, API extends PlatformApi = any>(factoryP
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle
     const _factoryParams = configureFactoryParams(factoryParams);
 
-    const loadConfig = async () => {
+    const loadConfig = async (params?: ComposableFunctionArgs<{}>) => {
       Logger.debug(`useConfig/${ssrKey}/loadConfig`);
       loading.value = true;
       try {
-        config.value = await _factoryParams.loadConfig();
+        config.value = await _factoryParams.loadConfig(params);
       } finally {
         loading.value = false;
       }

--- a/packages/composables/src/factories/useContentFactory.ts
+++ b/packages/composables/src/factories/useContentFactory.ts
@@ -1,5 +1,6 @@
 import { computed, Ref } from '@vue/composition-api';
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
   FactoryParams,
@@ -10,8 +11,8 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseContentErrors, UseContent } from '../types/composables';
 
 export interface UseContentFactoryParams<CONTENT, BLOCK, API extends PlatformApi = any> extends FactoryParams<API>{
-  loadContent: (context: Context, identifier: string) => Promise<CONTENT>;
-  loadBlocks: (context: Context, identifiers: string[]) => Promise<BLOCK[]>;
+  loadContent: (context: Context, params: ComposableFunctionArgs<{ identifier: string }>) => Promise<CONTENT>;
+  loadBlocks: (context: Context, params: ComposableFunctionArgs<{ identifiers: string[] }>) => Promise<BLOCK[]>;
 }
 
 export function useContentFactory<CONTENT, BLOCK, API extends PlatformApi = any>(
@@ -29,13 +30,13 @@ export function useContentFactory<CONTENT, BLOCK, API extends PlatformApi = any>
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle
     const _factoryParams = configureFactoryParams(factoryParams);
 
-    const loadContent = async (identifier: string) => {
+    const loadContent = async (params: ComposableFunctionArgs<{ identifier: string }>) => {
       Logger.debug(`useContent/${ssrKey}/loadPage`);
       loading.value = true;
 
       try {
         errors.value.content = null;
-        page.value = await _factoryParams.loadContent(identifier);
+        page.value = await _factoryParams.loadContent(params);
       } catch (error) {
         errors.value.content = error;
       } finally {
@@ -43,13 +44,13 @@ export function useContentFactory<CONTENT, BLOCK, API extends PlatformApi = any>
       }
     };
 
-    const loadBlocks = async (identifiers: string[]) => {
+    const loadBlocks = async (params: ComposableFunctionArgs<{ identifiers: string[] }>) => {
       Logger.debug(`useContent/${ssrKey}/loadBlocks`);
       loading.value = true;
 
       try {
         errors.value.blocks = null;
-        blocks.value = await _factoryParams.loadBlocks(identifiers);
+        blocks.value = await _factoryParams.loadBlocks(params);
       } catch (error) {
         errors.value.blocks = error;
       } finally {

--- a/packages/composables/src/factories/useCountrySearchFactory.ts
+++ b/packages/composables/src/factories/useCountrySearchFactory.ts
@@ -3,14 +3,14 @@ import {
   Context,
   sharedRef,
   Logger,
-  configureFactoryParams, FactoryParams,
+  configureFactoryParams, FactoryParams, ComposableFunctionArgs,
 } from '@vue-storefront/core';
 import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseCountrySearch, UseCountrySearchErrors } from '../types/composables';
 
 export interface UseCountryFactoryParams<COUNTRIES, COUNTRY, API extends PlatformApi = any> extends FactoryParams<API>{
-  load: (context: Context) => Promise<COUNTRIES[]>;
-  search: (context: Context, params: { id: string }) => Promise<COUNTRY>;
+  load: (context: Context, params?: ComposableFunctionArgs<{}>) => Promise<COUNTRIES[]>;
+  search: (context: Context, params: ComposableFunctionArgs<{ id: string }>) => Promise<COUNTRY>;
 }
 
 export function useCountrySearchFactory<COUNTRIES,
@@ -30,13 +30,13 @@ export function useCountrySearchFactory<COUNTRIES,
     const _factoryParams = configureFactoryParams(factoryParams);
 
     // eslint-disable-next-line consistent-return
-    const load = async (): Promise<COUNTRIES[]> => {
+    const load = async (params?: ComposableFunctionArgs<{}>): Promise<COUNTRIES[]> => {
       Logger.debug(`useCountrySearch/${ssrKey}/load`);
 
       try {
         loading.value = true;
 
-        const data = await _factoryParams.load();
+        const data = await _factoryParams.load(params);
 
         countries.value = data;
 
@@ -52,7 +52,7 @@ export function useCountrySearchFactory<COUNTRIES,
     };
 
     // eslint-disable-next-line consistent-return
-    const search = async (params: { id: string }): Promise<COUNTRY> => {
+    const search = async (params: ComposableFunctionArgs<{ id: string }>): Promise<COUNTRY> => {
       Logger.debug(`useCountrySearch/${ssrKey}/search`);
 
       try {

--- a/packages/composables/src/factories/useCurrencyFactory.ts
+++ b/packages/composables/src/factories/useCurrencyFactory.ts
@@ -4,14 +4,14 @@ import {
   sharedRef,
   Logger,
   configureFactoryParams,
-  FactoryParams,
+  FactoryParams, ComposableFunctionArgs,
 } from '@vue-storefront/core';
 import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseCurrency } from '../types/composables';
 
 export interface UseCurrencyFactoryParams<CURRENCY, API extends PlatformApi = any> extends FactoryParams<API> {
-  load: (context: Context) => Promise<CURRENCY>;
-  change: (context: Context, params) => void
+  load: (context: Context, params?: ComposableFunctionArgs<{}>) => Promise<CURRENCY>;
+  change: (context: Context, params: ComposableFunctionArgs<{ id: string }>) => void
 }
 
 export function useCurrencyFactory<CURRENCY,
@@ -25,17 +25,17 @@ export function useCurrencyFactory<CURRENCY,
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle
     const _factoryParams = configureFactoryParams(factoryParams);
 
-    const load = async () => {
+    const load = async (params?: ComposableFunctionArgs<{}>) => {
       Logger.debug(`useCurrency/${ssrKey}/load`);
       loading.value = true;
       try {
-        currencies.value = await _factoryParams.load();
+        currencies.value = await _factoryParams.load(params);
       } finally {
         loading.value = false;
       }
     };
 
-    const change = async (params) => {
+    const change = async (params: ComposableFunctionArgs<{ id: string }>) => {
       Logger.debug(`useCurrency/${ssrKey}/change`);
       loading.value = true;
       try {

--- a/packages/composables/src/factories/useExternalCheckoutFactory.ts
+++ b/packages/composables/src/factories/useExternalCheckoutFactory.ts
@@ -1,4 +1,5 @@
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
   FactoryParams,
@@ -10,7 +11,7 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseExternalCheckout } from '../types/composables';
 
 export interface UseExternalCheckoutFactoryParams<API extends PlatformApi = any> extends FactoryParams<API> {
-  initializeCheckout: (context: Context, baseUrl: string) => Promise<string>;
+  initializeCheckout: (context: Context, params: ComposableFunctionArgs<{ baseUrl: string }>) => Promise<string>;
 }
 
 export const useExternalCheckoutFactory = <API extends PlatformApi = any>(
@@ -25,12 +26,12 @@ export const useExternalCheckoutFactory = <API extends PlatformApi = any>(
     const _factoryParams = configureFactoryParams(factoryParams);
 
     // eslint-disable-next-line @typescript-eslint/require-await,consistent-return
-    const initializeCheckout = async (baseUrl: string): Promise<string> => {
+    const initializeCheckout = async (params: ComposableFunctionArgs<{ baseUrl: string }>): Promise<string> => {
       Logger.debug(`useExternalCheckout/${ssrKey}/initializeCheckout`);
       loading.value = true;
 
       try {
-        return _factoryParams.initializeCheckout(baseUrl);
+        return _factoryParams.initializeCheckout(params);
       } catch (err) {
         error.value.search = err;
 

--- a/packages/composables/src/factories/useForgotPasswordFactory.ts
+++ b/packages/composables/src/factories/useForgotPasswordFactory.ts
@@ -1,5 +1,6 @@
 import { Ref, computed } from '@vue/composition-api';
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
   CustomQuery,
@@ -20,8 +21,8 @@ interface ResetPasswordParams {
 }
 
 export interface UseForgotPasswordFactoryParams<RESULT> extends FactoryParams {
-  resetPassword: (context: Context, params: ResetPasswordParams & { currentResult: RESULT, customQuery?: CustomQuery }) => Promise<RESULT>;
-  setNewPassword: (context: Context, params: SetNewPasswordParams & { currentResult: RESULT, customQuery?: CustomQuery }) => Promise<RESULT>;
+  resetPassword: (context: Context, params: ComposableFunctionArgs<ResetPasswordParams & { currentResult: RESULT }>) => Promise<RESULT>;
+  setNewPassword: (context: Context, params: ComposableFunctionArgs<SetNewPasswordParams & { currentResult: RESULT }>) => Promise<RESULT>;
 }
 
 export function useForgotPasswordFactory<RESULT>(
@@ -40,7 +41,7 @@ export function useForgotPasswordFactory<RESULT>(
       setNew: null,
     }, 'useForgotPassword-error');
 
-    const request = async (resetPasswordParams: ResetPasswordParams) => {
+    const request = async (resetPasswordParams: ComposableFunctionArgs<ResetPasswordParams>) => {
       Logger.debug('useForgotPassword/request', resetPasswordParams.email);
 
       try {
@@ -56,7 +57,7 @@ export function useForgotPasswordFactory<RESULT>(
       }
     };
 
-    const setNew = async (setNewPasswordParams: SetNewPasswordParams) => {
+    const setNew = async (setNewPasswordParams: ComposableFunctionArgs<SetNewPasswordParams>) => {
       Logger.debug('useForgotPassword/setNew', setNewPasswordParams);
 
       try {

--- a/packages/composables/src/factories/useGetShippingMethodsFactory.ts
+++ b/packages/composables/src/factories/useGetShippingMethodsFactory.ts
@@ -1,5 +1,6 @@
 import { computed, Ref } from '@vue/composition-api';
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
   FactoryParams,
@@ -10,7 +11,7 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseGetShippingMethods, UseGetShippingMethodsErrors } from '../types/composables';
 
 export interface UseGetShippingMethodsFactory<SHIPPING_METHOD, API extends PlatformApi = any> extends FactoryParams<API> {
-  load: (context: Context, params: { cartId: string }) => Promise<SHIPPING_METHOD[]>;
+  load: (context: Context, params: ComposableFunctionArgs<{ cartId: string }>) => Promise<SHIPPING_METHOD[]>;
 }
 
 export function useGetShippingMethodsFactory<SHIPPING_METHOD, API extends PlatformApi = any>(
@@ -28,8 +29,8 @@ export function useGetShippingMethodsFactory<SHIPPING_METHOD, API extends Platfo
     const _factoryParams = configureFactoryParams(factoryParams);
 
     // eslint-disable-next-line consistent-return
-    const load = async (params: { cartId: string }): Promise<SHIPPING_METHOD[]> => {
-      Logger.debug(`useGetShippingMethods/${ssrKey}/load`);
+    const load = async (params: ComposableFunctionArgs<{ cartId: string }>): Promise<SHIPPING_METHOD[]> => {
+      Logger.debug(`useGetShippingMethods/${ssrKey}/load`, { params });
 
       try {
         loading.value = true;

--- a/packages/composables/src/factories/useGuestUserFactory.ts
+++ b/packages/composables/src/factories/useGuestUserFactory.ts
@@ -4,7 +4,7 @@ import {
   configureFactoryParams,
   FactoryParams,
   Logger,
-  sharedRef,
+  sharedRef, ComposableFunctionArgs,
 } from '@vue-storefront/core';
 import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseGuestUser, UseGuestUserErrors } from '../types/composables';
@@ -12,14 +12,14 @@ import { UseGuestUser, UseGuestUserErrors } from '../types/composables';
 export interface UseGuestUserFactoryParams<GUEST_USER,
   REGISTER_GUEST_USER_PARAMS,
   API extends PlatformApi = any> extends FactoryParams<API> {
-  attachToCart: (context: Context, params: REGISTER_GUEST_USER_PARAMS) => Promise<GUEST_USER>;
+  attachToCart: (context: Context, params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>) => Promise<GUEST_USER>;
 }
 
 export const useGuestUserFactory = <GUEST_USER,
   REGISTER_GUEST_USER_PARAMS extends { email: string; password: string },
   API extends PlatformApi = any>(
   factoryParams: UseGuestUserFactoryParams<GUEST_USER, REGISTER_GUEST_USER_PARAMS, API>,
-) => function useGuestUser(): UseGuestUser<GUEST_USER, API> {
+) => function useGuestUser(): UseGuestUser<GUEST_USER, REGISTER_GUEST_USER_PARAMS, API> {
   const errorsFactory = (): UseGuestUserErrors => ({
     attachToCart: null,
   });
@@ -39,13 +39,13 @@ export const useGuestUserFactory = <GUEST_USER,
     error.value = errorsFactory();
   };
 
-  const attachToCart = async ({ user: providedUser }) => {
-    Logger.debug('useGuestUserFactory.attachToCart', providedUser);
+  const attachToCart = async (params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>) => {
+    Logger.debug('useGuestUserFactory.attachToCart', { params });
     resetErrorValue();
 
     try {
       loading.value = true;
-      guestUser.value = await _factoryParams.attachToCart(providedUser);
+      guestUser.value = await _factoryParams.attachToCart(params);
       error.value.attachToCart = null;
     } catch (err) {
       error.value.attachToCart = err;

--- a/packages/composables/src/factories/useNewsletterFactory.ts
+++ b/packages/composables/src/factories/useNewsletterFactory.ts
@@ -1,5 +1,6 @@
 import { Ref, computed } from '@vue/composition-api';
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
   FactoryParams,
@@ -10,7 +11,7 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseNewsletter, UseNewsletterErrors } from '../types/composables';
 
 export interface UseNewsletterFactoryParams<NEWSLETTER, UPDATE_NEWSLETTER_PARAMS, API extends PlatformApi = any> extends FactoryParams<API> {
-  updateSubscription: (context: Context, params: { email: UPDATE_NEWSLETTER_PARAMS }) => Promise<NEWSLETTER>;
+  updateSubscription: (context: Context, params: ComposableFunctionArgs<{ email: UPDATE_NEWSLETTER_PARAMS }>) => Promise<NEWSLETTER>;
 }
 
 export const useNewsletterFactory = <NEWSLETTER, UPDATE_NEWSLETTER_PARAMS, API extends PlatformApi = any>(
@@ -29,7 +30,7 @@ export const useNewsletterFactory = <NEWSLETTER, UPDATE_NEWSLETTER_PARAMS, API e
     error.value = errorsFactory();
   };
 
-  const updateSubscription = async (params) => {
+  const updateSubscription = async (params: ComposableFunctionArgs<{ email: UPDATE_NEWSLETTER_PARAMS }>) => {
     Logger.debug('useNewsletterFactory.updateSubscription', params);
     resetErrorValue();
 

--- a/packages/composables/src/factories/usePaymentProviderFactory.ts
+++ b/packages/composables/src/factories/usePaymentProviderFactory.ts
@@ -1,8 +1,8 @@
 import { Ref, computed } from '@vue/composition-api';
 import {
+  ComposableFunctionArgs,
   configureFactoryParams,
   Context,
-  CustomQuery,
   FactoryParams,
   Logger,
   sharedRef,
@@ -11,8 +11,8 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UsePaymentProvider, UsePaymentProviderErrors } from '../types/composables';
 
 export interface UsePaymentProviderParams<STATE, PAYMENT_METHOD, API extends PlatformApi = any> extends FactoryParams<API> {
-  load: (context: Context, params: { state: Ref<STATE>, customQuery?: CustomQuery }) => Promise<STATE>;
-  save: (context: Context, params: { state: Ref<STATE>, paymentMethod: PAYMENT_METHOD, customQuery?: CustomQuery }) => Promise<STATE>;
+  load: (context: Context, params?: ComposableFunctionArgs<{ }>) => Promise<STATE>;
+  save: (context: Context, params: ComposableFunctionArgs<{ paymentMethod: PAYMENT_METHOD }>) => Promise<STATE>;
 }
 
 export const usePaymentProviderFactory = <STATE, PAYMENT_METHOD, API extends PlatformApi = any>(
@@ -32,12 +32,16 @@ export const usePaymentProviderFactory = <STATE, PAYMENT_METHOD, API extends Pla
     Logger.debug('usePaymentProvider.setState', newState);
   };
 
-  const save = async ({ paymentMethod, customQuery = null }) => {
+  const save = async (params: ComposableFunctionArgs<{ paymentMethod: PAYMENT_METHOD }>) => {
     Logger.debug('usePaymentProvider.save');
 
     try {
       loading.value = true;
-      state.value = await _factoryParams.save({ paymentMethod, customQuery, state });
+      state.value = await _factoryParams.save({
+        paymentMethod: params.paymentMethod || {},
+        customQuery: params.customQuery || {},
+        state,
+      });
       error.value.save = null;
     } catch (err) {
       error.value.save = err;
@@ -47,12 +51,15 @@ export const usePaymentProviderFactory = <STATE, PAYMENT_METHOD, API extends Pla
     }
   };
 
-  const load = async ({ customQuery = null } = {}) => {
+  const load = async (params?: ComposableFunctionArgs<{}>) => {
     Logger.debug('usePaymentProvider.load');
 
     try {
       loading.value = true;
-      state.value = await _factoryParams.load({ customQuery, state });
+      state.value = await _factoryParams.load({
+        customQuery: params.customQuery || {},
+        state,
+      });
       error.value.load = null;
     } catch (err) {
       error.value.load = err;

--- a/packages/composables/src/factories/useRelatedProductsFactory.ts
+++ b/packages/composables/src/factories/useRelatedProductsFactory.ts
@@ -7,7 +7,7 @@ import {
   ProductsSearchParams,
   sharedRef,
 } from '@vue-storefront/core';
-import { PlatformApi } from '@vue-storefront/core/lib/src/types';
+import { ComposableFunctionArgs, PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseRelatedProducts, UseRelatedProductsErrors } from '../types/composables';
 
 export interface UseRelatedProductsFactoryParams<
@@ -15,7 +15,7 @@ export interface UseRelatedProductsFactoryParams<
   RELATED_PRODUCTS_SEARCH_PARAMS extends ProductsSearchParams,
   API extends PlatformApi = any,
 > extends FactoryParams<API> {
-  productsSearch: (context: Context, params: RELATED_PRODUCTS_SEARCH_PARAMS & { customQuery?: CustomQuery }) => Promise<PRODUCTS>;
+  productsSearch: (context: Context, params: ComposableFunctionArgs<RELATED_PRODUCTS_SEARCH_PARAMS>) => Promise<PRODUCTS>;
 }
 
 export function useRelatedProductsFactory<PRODUCTS, RELATED_PRODUCTS_SEARCH_PARAMS, API extends PlatformApi = any>(
@@ -36,7 +36,7 @@ export function useRelatedProductsFactory<PRODUCTS, RELATED_PRODUCTS_SEARCH_PARA
       },
     );
 
-    const search = async (searchParams) => {
+    const search = async (searchParams: ComposableFunctionArgs<RELATED_PRODUCTS_SEARCH_PARAMS>) => {
       Logger.debug(`useRelatedProducts/${id}/search`, searchParams);
 
       try {

--- a/packages/composables/src/factories/useReviewFactory.ts
+++ b/packages/composables/src/factories/useReviewFactory.ts
@@ -18,8 +18,8 @@ export interface UseReviewFactoryParams<REVIEW,
   REVIEW_METADATA,
   API extends PlatformApi = any> extends FactoryParams<API> {
   searchReviews: (context: Context, params: ComposableFunctionArgs<REVIEWS_SEARCH_PARAMS>) => Promise<REVIEW>;
-  addReview: (context: Context, params: REVIEW_ADD_PARAMS & { customQuery?: CustomQuery }) => Promise<REVIEW>;
-  loadReviewMetadata: (context: Context) => Promise<REVIEW_METADATA[]>;
+  addReview: (context: Context, params: ComposableFunctionArgs<REVIEW_ADD_PARAMS>) => Promise<REVIEW>;
+  loadReviewMetadata: (context: Context, params?: ComposableFunctionArgs<{}>) => Promise<REVIEW_METADATA[]>;
   loadCustomerReviews: (context: Context, params: ComposableFunctionArgs<REVIEWS_USER_SEARCH_PARAMS>) => Promise<REVIEW>;
 }
 
@@ -55,7 +55,7 @@ export function useReviewFactory<
     // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle
     const _factoryParams = configureFactoryParams(factoryParams);
 
-    const search = async (searchParams?: REVIEWS_SEARCH_PARAMS): Promise<void> => {
+    const search = async (searchParams?: ComposableFunctionArgs<REVIEWS_SEARCH_PARAMS>): Promise<void> => {
       Logger.debug(`useReview/${id}/search`, searchParams);
 
       try {
@@ -70,7 +70,7 @@ export function useReviewFactory<
       }
     };
 
-    const loadCustomerReviews = async (searchParams?: REVIEWS_USER_SEARCH_PARAMS): Promise<void> => {
+    const loadCustomerReviews = async (searchParams?: ComposableFunctionArgs<REVIEWS_USER_SEARCH_PARAMS>): Promise<void> => {
       Logger.debug(`useReview/${id}/loadCustomerReviews`, searchParams);
 
       try {
@@ -85,12 +85,12 @@ export function useReviewFactory<
       }
     };
 
-    const loadReviewMetadata = async (): Promise<void> => {
+    const loadReviewMetadata = async (params?: ComposableFunctionArgs<{}>): Promise<void> => {
       Logger.debug(`useReview/${id}/loadReviewMetadata`);
 
       try {
         loading.value = true;
-        metadatas.value = await _factoryParams.loadReviewMetadata();
+        metadatas.value = await _factoryParams.loadReviewMetadata(params);
         error.value.loadReviewMetadata = null;
       } catch (err) {
         error.value.loadReviewMetadata = err;
@@ -100,7 +100,7 @@ export function useReviewFactory<
       }
     };
 
-    const addReview = async (params): Promise<void> => {
+    const addReview = async (params: ComposableFunctionArgs<REVIEW_ADD_PARAMS>): Promise<void> => {
       Logger.debug(`useReview/${id}/addReview`, params);
 
       try {

--- a/packages/composables/src/factories/useUpsellProductsFactory.ts
+++ b/packages/composables/src/factories/useUpsellProductsFactory.ts
@@ -1,14 +1,13 @@
 import { computed, Ref } from '@vue/composition-api';
 import {
   configureFactoryParams,
-  CustomQuery,
   FactoryParams,
   Logger,
   Context,
   ProductsSearchParams,
   sharedRef, UseProductFactoryParams,
 } from '@vue-storefront/core';
-import { PlatformApi } from '@vue-storefront/core/lib/src/types';
+import { ComposableFunctionArgs, PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseUpsellProducts, UseUpsellProductsErrors } from '../types/composables';
 
 export interface UseUpsellProductsFactoryParams<
@@ -16,7 +15,7 @@ export interface UseUpsellProductsFactoryParams<
   UPSELL_PRODUCTS_SEARCH_PARAMS extends ProductsSearchParams,
   API extends PlatformApi = any,
 > extends FactoryParams<API> {
-  productsSearch: (context: Context, params: UPSELL_PRODUCTS_SEARCH_PARAMS & { customQuery?: CustomQuery }) => Promise<PRODUCTS>;
+  productsSearch: (context: Context, params: ComposableFunctionArgs<UPSELL_PRODUCTS_SEARCH_PARAMS>) => Promise<PRODUCTS>;
 }
 
 export function useUpsellProductsFactory<PRODUCTS, UPSELL_PRODUCTS_SEARCH_PARAMS, API extends PlatformApi = any>(
@@ -37,7 +36,7 @@ export function useUpsellProductsFactory<PRODUCTS, UPSELL_PRODUCTS_SEARCH_PARAMS
       },
     );
 
-    const search = async (searchParams) => {
+    const search = async (searchParams: ComposableFunctionArgs<UPSELL_PRODUCTS_SEARCH_PARAMS>) => {
       Logger.debug(`useUpsellProducts/${id}/search`, searchParams);
 
       try {

--- a/packages/composables/src/factories/useUrlResolverFactory.ts
+++ b/packages/composables/src/factories/useUrlResolverFactory.ts
@@ -6,11 +6,11 @@ import {
   sharedRef,
 } from '@vue-storefront/core';
 import { computed } from '@vue/composition-api';
-import { PlatformApi } from '@vue-storefront/core/lib/src/types';
+import { ComposableFunctionArgs, PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseUrlResolver } from '../types/composables';
 
 export interface UseUrlResolverFactoryParams<ROUTER, API extends PlatformApi = any> extends FactoryParams<API> {
-  search: (context: Context, url: string) => Promise<ROUTER>;
+  search: (context: Context, params: ComposableFunctionArgs<{ url: string }>) => Promise<ROUTER>;
 }
 
 export const useUrlResolverFactory = <ROUTER, API extends PlatformApi = any>(
@@ -26,12 +26,12 @@ export const useUrlResolverFactory = <ROUTER, API extends PlatformApi = any>(
   const _factoryParams = configureFactoryParams(factoryParams);
 
   // eslint-disable-next-line consistent-return
-  const search = async (url: string) => {
+  const search = async (params: ComposableFunctionArgs<{ url: string }>) => {
     Logger.debug(`useRouter/${ssrKey}/search`);
     loading.value = true;
 
     try {
-      const data = await _factoryParams.search(url);
+      const data = await _factoryParams.search(params);
 
       result.value = data;
 

--- a/packages/composables/src/factories/useWishlistFactory.ts
+++ b/packages/composables/src/factories/useWishlistFactory.ts
@@ -10,34 +10,31 @@ import {
   Logger,
   sharedRef,
 } from '@vue-storefront/core';
-import { PlatformApi } from '@vue-storefront/core/lib/src/types';
+import { ComposableFunctionArgs, PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { UseWishlist, UseWishlistErrors } from '../types/composables';
 
 export interface UseWishlistFactoryParams<WISHLIST,
   WISHLIST_ITEM,
   PRODUCT,
   API extends PlatformApi = any> extends FactoryParams<API> {
-  load: (context: Context, params: {
+  load: (context: Context, params: ComposableFunctionArgs<{
     searchParams?: Partial<{
       currentPage: number;
       pageSize: number;
     }>,
-    customQuery?: CustomQuery,
-  }) => Promise<WISHLIST>;
+  }>) => Promise<WISHLIST>;
   addItem: (
     context: Context,
-    params: {
+    params: ComposableFunctionArgs<{
       currentWishlist: WISHLIST;
       product: PRODUCT;
-      customQuery?: CustomQuery;
-    }) => Promise<WISHLIST>;
+    }>) => Promise<WISHLIST>;
   removeItem: (
     context: Context,
-    params: {
+    params: ComposableFunctionArgs<{
       currentWishlist: WISHLIST;
       product: WISHLIST_ITEM;
-      customQuery?: CustomQuery;
-    }) => Promise<WISHLIST>;
+    }>) => Promise<WISHLIST>;
   clear: (context: Context, params: { currentWishlist: WISHLIST }) => Promise<WISHLIST>;
   isInWishlist: (context: Context, params: { currentWishlist: WISHLIST; product: PRODUCT }) => boolean;
 }
@@ -71,10 +68,7 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT, API extends
       Logger.debug(`useWishlistFactory/${ssrKey}/setWishlist`, newWishlist);
     };
 
-    const addItem = async ({
-                             product,
-                             customQuery,
-                           }) => {
+    const addItem = async ({ product, customQuery }) => {
       Logger.debug(`useWishlist/${ssrKey}/addItem`, product);
 
       try {
@@ -94,10 +88,7 @@ export const useWishlistFactory = <WISHLIST, WISHLIST_ITEM, PRODUCT, API extends
       }
     };
 
-    const removeItem = async ({
-                                product,
-                                customQuery,
-                              }) => {
+    const removeItem = async ({ product, customQuery }) => {
       Logger.debug(`useWishlist/${ssrKey}/removeItem`, product);
 
       try {

--- a/packages/composables/src/types/composables.ts
+++ b/packages/composables/src/types/composables.ts
@@ -8,10 +8,10 @@ import { ComputedRef } from '@vue/composition-api';
 import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { FetchPolicy } from './index';
 
-export type CustomQueryParams = { customQuery?: CustomQuery; [ k: string]: any };
+export type CustomQueryParams = { customQuery?: CustomQuery; [k: string]: any };
 
-export interface UseUrlResolver<ROUTE, API extends PlatformApi = any> extends Composable<API>{
-  search: (url: string) => Promise<void>;
+export interface UseUrlResolver<ROUTE, API extends PlatformApi = any> extends Composable<API> {
+  search: (params: ComposableFunctionArgs<{ url: string }>) => Promise<void>;
   result: ComputedProperty<ROUTE>;
   error: ComputedProperty<UseRouterErrors>;
   loading: ComputedProperty<boolean>;
@@ -21,8 +21,8 @@ export interface UseRouterErrors {
   search: Error;
 }
 
-export interface UseExternalCheckout<API extends PlatformApi = any> extends Composable<API>{
-  initializeCheckout: (baseUrl: string) => Promise<string>;
+export interface UseExternalCheckout<API extends PlatformApi = any> extends Composable<API> {
+  initializeCheckout: (params: ComposableFunctionArgs<{ baseUrl: string }>) => Promise<string>;
   error: ComputedProperty<UseExternalCheckoutErrors>;
   loading: ComputedProperty<boolean>;
 }
@@ -31,8 +31,8 @@ export interface UseExternalCheckoutErrors {
   initializeCheckout: Error;
 }
 
-export interface UseCategorySearch<CATEGORY, API extends PlatformApi = any> extends Composable<API>{
-  search: (params: { term: string }) => Promise<CATEGORY[]>;
+export interface UseCategorySearch<CATEGORY, CATEGORY_SEARCH_PARAMS, API extends PlatformApi = any> extends Composable<API> {
+  search: (params: ComposableFunctionArgs<CATEGORY_SEARCH_PARAMS>) => Promise<CATEGORY[]>;
   result: ComputedProperty<CATEGORY[]>;
   error: ComputedProperty<UseCategorySearchErrors>;
   loading: ComputedProperty<boolean>;
@@ -43,8 +43,8 @@ export interface UseCategorySearchErrors {
 }
 
 export interface UseCountrySearch<COUNTRIES, COUNTRY, API extends PlatformApi = any> extends Composable<API> {
-  load: () => Promise<COUNTRIES[]>;
-  search: (params: { id: string }) => Promise<COUNTRY>;
+  load: (params?: ComposableFunctionArgs<{}>) => Promise<COUNTRIES[]>;
+  search: (params: ComposableFunctionArgs<{ id: string }>) => Promise<COUNTRY>;
   countries: ComputedProperty<COUNTRIES[]>;
   country: ComputedProperty<COUNTRY>;
   error: ComputedProperty<UseCountrySearchErrors>;
@@ -58,7 +58,7 @@ export interface UseCountrySearchErrors {
 
 export interface UseConfig<CONFIG, API extends PlatformApi = any> extends Composable<API> {
   config: ComputedRef<CONFIG>;
-  loadConfig: () => Promise<void>;
+  loadConfig: (params?: ComposableFunctionArgs<{}>) => Promise<void>;
   loading: ComputedRef<boolean>;
 }
 
@@ -67,21 +67,21 @@ export interface UseContentErrors {
   blocks: Error;
 }
 
-export interface UseContent<PAGE, BLOCK, API extends PlatformApi = any> extends Composable<API>{
+export interface UseContent<PAGE, BLOCK, API extends PlatformApi = any> extends Composable<API> {
   page: ComputedProperty<PAGE>;
   blocks: ComputedProperty<BLOCK[]>
-  loadContent: (identifier: string) => Promise<void>;
-  loadBlocks: (identifiers: string[]) => Promise<void>;
+  loadContent: (params: ComposableFunctionArgs<{ identifier: string }>) => Promise<void>;
+  loadBlocks: (params: ComposableFunctionArgs<{ identifiers: string[] }>) => Promise<void>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseContentErrors>;
 }
 
-export interface UseGetShippingMethods<SHIPPING_METHOD, API extends PlatformApi = any> extends Composable<API>{
+export interface UseGetShippingMethods<SHIPPING_METHOD, API extends PlatformApi = any> extends Composable<API> {
   state: ComputedProperty<SHIPPING_METHOD[]>;
 
   setState(state: SHIPPING_METHOD[]): void;
 
-  load: (params: { cartId: string }) => Promise<SHIPPING_METHOD[]>;
+  load: (params: ComposableFunctionArgs<{ cartId: string }>) => Promise<SHIPPING_METHOD[]>;
   result: ComputedProperty<SHIPPING_METHOD[]>;
   error: ComputedProperty<UseGetShippingMethodsErrors>;
   loading: ComputedProperty<boolean>;
@@ -96,18 +96,16 @@ export interface UsePaymentProviderErrors {
   save: Error;
 }
 
-export interface UsePaymentProvider<STATE, PAYMENT_METHOD, API extends PlatformApi = any> extends Composable<API>{
+export interface UsePaymentProvider<STATE, PAYMENT_METHOD, API extends PlatformApi = any> extends Composable<API> {
   error: ComputedProperty<UsePaymentProviderErrors>;
   loading: ComputedProperty<boolean>;
   state: ComputedProperty<STATE>;
 
   setState(state: STATE): void;
 
-  load(): Promise<void>;
+  load(params?: ComposableFunctionArgs<{}>): Promise<void>;
 
-  load(params: { customQuery?: CustomQuery }): Promise<void>;
-
-  save(params: { paymentMethod: PAYMENT_METHOD, customQuery?: CustomQuery }): Promise<void>;
+  save(params: ComposableFunctionArgs<{ paymentMethod: PAYMENT_METHOD }>): Promise<void>;
 }
 
 export interface UseGuestUserErrors {
@@ -123,10 +121,10 @@ export interface UseGuestUserRegisterParams {
   [x: string]: any;
 }
 
-export interface UseGuestUser<GUEST_USER, API extends PlatformApi = any> extends Composable<API>{
+export interface UseGuestUser<GUEST_USER, REGISTER_GUEST_USER_PARAMS, API extends PlatformApi = any> extends Composable<API> {
   guestUser: ComputedProperty<GUEST_USER>;
   setGuestUser: (user: GUEST_USER) => void;
-  attachToCart: (params: { user: UseGuestUserRegisterParams }) => Promise<void>;
+  attachToCart: (params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>) => Promise<void>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseGuestUserErrors>;
 }
@@ -143,14 +141,14 @@ export interface UseReview<REVIEW,
   REVIEWS_USER_SEARCH_PARAMS,
   REVIEW_ADD_PARAMS,
   REVIEW_METADATA,
-  API extends PlatformApi = any> extends Composable<API>{
+  API extends PlatformApi = any> extends Composable<API> {
   search(params?: ComposableFunctionArgs<REVIEWS_SEARCH_PARAMS>): Promise<void>;
 
   loadCustomerReviews(params?: ComposableFunctionArgs<REVIEWS_USER_SEARCH_PARAMS>): Promise<void>;
 
   addReview(params: ComposableFunctionArgs<REVIEW_ADD_PARAMS>): Promise<void>;
 
-  loadReviewMetadata(): Promise<void>;
+  loadReviewMetadata(params?: ComposableFunctionArgs<{}>): Promise<void>;
 
   error: ComputedProperty<UseReviewErrors>;
   reviews: ComputedProperty<REVIEW>;
@@ -164,10 +162,10 @@ export interface UseNewsletterErrors {
   updateSubscription: Error;
 }
 
-export interface UseNewsletter<UPDATE_NEWSLETTER_PARAMS, API extends PlatformApi = any> extends Composable<API>{
+export interface UseNewsletter<UPDATE_NEWSLETTER_PARAMS, API extends PlatformApi = any> extends Composable<API> {
   error: ComputedProperty<UseNewsletterErrors>;
   loading: ComputedProperty<boolean>;
-  updateSubscription: (params: { email: UPDATE_NEWSLETTER_PARAMS }) => Promise<void>;
+  updateSubscription: (params: ComposableFunctionArgs<{ email: UPDATE_NEWSLETTER_PARAMS }>) => Promise<void>;
 }
 
 export interface UseAddressesErrors {
@@ -202,7 +200,9 @@ export interface UseForgotPassword<RESULT> {
   result: ComputedProperty<RESULT>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseForgotPasswordErrors>;
+
   setNew(params: ComposableFunctionArgs<{ tokenValue: string, newPassword: string, email: string }>): Promise<void>;
+
   request(params: ComposableFunctionArgs<{ email: string }>): Promise<void>;
 }
 
@@ -210,7 +210,9 @@ export interface UseRelatedProducts<PRODUCTS, RELATED_PRODUCT_SEARCH_PARAMS, API
   products: ComputedProperty<PRODUCTS>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseRelatedProductsErrors>;
+
   search(params: ComposableFunctionArgs<RELATED_PRODUCT_SEARCH_PARAMS>): Promise<void>;
+
   [x: string]: any;
 }
 
@@ -222,7 +224,9 @@ export interface UseUpsellProducts<PRODUCTS, UPSELL_PRODUCTS_SEARCH_PARAMS, API 
   products: ComputedProperty<PRODUCTS>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseUpsellProductsErrors>;
+
   search(params: ComposableFunctionArgs<UPSELL_PRODUCTS_SEARCH_PARAMS>): Promise<void>;
+
   [x: string]: any;
 }
 
@@ -244,6 +248,7 @@ export interface UseCustomQuery<QUERY, QUERY_VARIABLES, QUERY_RETURN, API extend
   result: ComputedProperty<QUERY_RETURN>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseUpsellProductsErrors>;
+
   [x: string]: any;
 }
 
@@ -265,6 +270,7 @@ export interface UseCustomMutation<MUTATION, MUTATION_VARIABLES, MUTATION_RETURN
   result: ComputedProperty<MUTATION_RETURN>;
   loading: ComputedProperty<boolean>;
   error: ComputedProperty<UseUpsellProductsErrors>;
+
   [x: string]: any;
 }
 
@@ -273,7 +279,7 @@ export interface UseUpsellProductsErrors {
 }
 
 export interface UseStore<STORES, STORE, API extends PlatformApi = any> extends Composable<API> {
-  load: () => Promise<void>;
+  load: (params?: ComposableFunctionArgs<{}>) => Promise<void>;
   change: (params: ComposableFunctionArgs<STORE>) => void;
   stores: ComputedRef<STORES>;
   loading: ComputedRef<boolean>;
@@ -284,8 +290,8 @@ export interface UseStoreErrors {
 }
 
 export interface UseCurrency<CURRENCY, API extends PlatformApi = any> extends Composable<API> {
-  load: () => Promise<void>;
-  change: (params: ComposableFunctionArgs<any>) => void;
+  load: (params?: ComposableFunctionArgs<{}>) => Promise<void>;
+  change: (params: ComposableFunctionArgs<{ id: string }>) => void;
   currencies: ComputedRef<CURRENCY>;
   loading: ComputedRef<boolean>;
 }
@@ -297,23 +303,30 @@ export interface UseWishlistErrors {
   clear: Error;
 }
 
-export interface UseWishlist
-<
-  WISHLIST,
+export interface UseWishlist<WISHLIST,
   WISHLIST_ITEM,
   PRODUCT,
   API extends PlatformApi = any,
 > extends Composable<API> {
   wishlist: ComputedProperty<WISHLIST>;
   loading: ComputedProperty<boolean>;
-  addItem(params: { product: PRODUCT; customQuery?: CustomQuery }): Promise<void>;
-  removeItem(params: { product: WISHLIST_ITEM; customQuery?: CustomQuery }): Promise<void>;
-  load(params: { searchParams?: Partial<{
-    currentPage: number;
-    pageSize: number;
-  }>, customQuery?: CustomQuery }): Promise<void>;
+
+  addItem(params: ComposableFunctionArgs<{ product: PRODUCT; }>): Promise<void>;
+
+  removeItem(params: ComposableFunctionArgs<{ product: WISHLIST_ITEM; }>): Promise<void>;
+
+  load(params: ComposableFunctionArgs<{
+    searchParams?: Partial<{
+      currentPage: number;
+      pageSize: number;
+    }>,
+  }>): Promise<void>;
+
   clear(): Promise<void>;
+
   setWishlist: (wishlist: WISHLIST) => void;
+
   isInWishlist({ product: PRODUCT }): boolean;
+
   error: ComputedProperty<UseWishlistErrors>;
 }

--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -277,9 +277,7 @@ export default defineComponent({
           itemsPerPage: 12,
           term: term.value,
         }),
-        categoriesSearch({
-          term: term.value,
-        }),
+        categoriesSearch({ filters: { name: { match: `${term.value}` } } }),
       ]);
 
       result.value = {

--- a/packages/theme/components/CurrencySelector.vue
+++ b/packages/theme/components/CurrencySelector.vue
@@ -22,7 +22,7 @@
             href="/"
             :class="selectedCurrency === currency ? 'container__currency--selected-label' : ''"
             @click.prevent="handleChanges({
-              callback: () => changeCurrency(currency),
+              callback: () => changeCurrency({id: currency}),
               redirect: false,
               refresh: true
             })"

--- a/packages/theme/composables/useUrlResolver.ts
+++ b/packages/theme/composables/useUrlResolver.ts
@@ -17,7 +17,7 @@ export const useUrlResolver = () => {
   return {
     path,
     search: async () => {
-      await search(path);
+      await search({ url: path });
       if (!result?.value) error({ statusCode: 404 });
     },
     result,

--- a/packages/theme/pages/MyAccount/MyProfile.vue
+++ b/packages/theme/pages/MyAccount/MyProfile.vue
@@ -105,8 +105,8 @@ export default defineComponent({
       onComplete,
       onError,
     }) => formHandler(async () => changePassword({
-      current: form.value.currentPassword,
-      new: form.value.newPassword,
+      currentPassword: form.value.currentPassword,
+      newPassword: form.value.newPassword,
     }), onComplete, onError);
 
     onSSR(async () => {


### PR DESCRIPTION
### 💅 Refactors
`api-client`
- updated `changeCustomerPassword` API params
- updated `generateCustomerToken` API params
- updated `mergeCarts` API params
- updated API types params

`composables`
- added missing customQuery calls
- BC: updated `urlResolver` `search` params to `{url: string}`
- BC: updated `useCurrency` `changeCurrency` params to `{id: string}`
- BC: updated `useUser` `changePassword` params to `{currentPassword: string; newPassword: string;}`

`theme`