### PR TITLE
fix: default billing information does not appear on address

### DIFF
--- a/packages/composables/src/getters/userAddressesGetters.ts
+++ b/packages/composables/src/getters/userAddressesGetters.ts
@@ -10,7 +10,10 @@ const userAddressesGetters: UserAddressesGetters = {
   getAddresses: (addresses, criteria?: Record<string, any>) => {
     if (!addresses || addresses.length === 0 || !Array.isArray(addresses)) return [];
 
-    const addressesData = addresses?.map((a) => transformUserGetter(a));
+    const addressesData = addresses?.map((a) => transformUserGetter(a))
+      ?.sort((a, b) => ((a.default_shipping === b.default_shipping) ? 0 : (a.default_shipping ? -1 : 1)))
+      ?.sort((a, b) => ((a.default_billing === b.default_billing) ? 0 : (a.default_billing ? -1 : 1)));
+    console.log(addressesData);
 
     if (!criteria || Object.keys(criteria).length === 0) {
       return addressesData;

--- a/packages/composables/src/getters/userAddressesGetters.ts
+++ b/packages/composables/src/getters/userAddressesGetters.ts
@@ -13,7 +13,6 @@ const userAddressesGetters: UserAddressesGetters = {
     const addressesData = addresses?.map((a) => transformUserGetter(a))
       ?.sort((a, b) => ((a.default_shipping === b.default_shipping) ? 0 : (a.default_shipping ? -1 : 1)))
       ?.sort((a, b) => ((a.default_billing === b.default_billing) ? 0 : (a.default_billing ? -1 : 1)));
-    console.log(addressesData);
 
     if (!criteria || Object.keys(criteria).length === 0) {
       return addressesData;

--- a/packages/theme/components/UserAddressDetails.vue
+++ b/packages/theme/components/UserAddressDetails.vue
@@ -26,13 +26,13 @@
         v-if="isDefaultShippingText"
         class="sf-badge--number color-info sf-badge"
       >
-        {{ isDefaultShippingText }}
+        {{ $t(isDefaultShippingText) }}
       </span>
       <span
         v-if="isDefaultBillingText"
         class="sf-badge--number color-info sf-badge"
       >
-        {{ isDefaultBillingText }}
+        {{ $t(isDefaultBillingText) }}
       </span>
     </small>
   </div>

--- a/packages/theme/components/UserAddressDetails.vue
+++ b/packages/theme/components/UserAddressDetails.vue
@@ -4,11 +4,6 @@
       :style="userAddress.isDefault ? 'font-weight: bold;' : ''"
     >
       {{ userAddress.firstName }} {{ userAddress.lastName }}
-      <small
-        v-if="addressDefaultText"
-      >
-        - {{ addressDefaultText }}
-      </small>
     </p>
     <p>{{ userAddress.street }}, {{ userAddress.streetNumber }}</p>
 
@@ -24,6 +19,22 @@
     >
       {{ userAddress.phone }}
     </p>
+    <small
+      v-if="isDefaultShippingText || isDefaultBillingText"
+    >
+      <span
+        v-if="isDefaultShippingText"
+        class="sf-badge--number color-info sf-badge"
+      >
+        {{ isDefaultShippingText }}
+      </span>
+      <span
+        v-if="isDefaultBillingText"
+        class="sf-badge--number color-info sf-badge"
+      >
+        {{ isDefaultBillingText }}
+      </span>
+    </small>
   </div>
 </template>
 
@@ -62,15 +73,14 @@ export default defineComponent({
       isDefaultBilling: userAddressesGetters.isDefaultBilling(address.value),
     }));
 
-    const addressDefaultText = computed(() => {
-      if (userAddress.value.isDefaultShipping) return 'Default Shipping Address';
-      if (userAddress.value.isDefaultBilling) return 'Default Billing Address';
-      return '';
-    });
+    const isDefaultShippingText = computed(() => (userAddress.value.isDefaultShipping ? 'Default Shipping Address' : ''));
+
+    const isDefaultBillingText = computed(() => (userAddress.value.isDefaultBilling ? 'Default Billing Address' : ''));
 
     return {
       userAddress,
-      addressDefaultText,
+      isDefaultShippingText,
+      isDefaultBillingText,
     };
   },
 });

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -166,4 +166,6 @@ export default {
   'Your current email address is': 'Your current email address is',
   forgotPasswordConfirmation: 'Thanks! If there is an account registered with the {0} email, you will find message with a password reset link in your inbox.',
   subscribeToNewsletterModalContent: 'After signing up for the newsletter, you will receive special offers and messages from VSF via email. We will not sell or distribute your email to any third party at any time. Please see our {0}.',
+  'Default Shipping Address': 'Default Shipping Address',
+  'Default Billing Address': 'Default Billing Address'
 };


### PR DESCRIPTION
Fix the missing text "default billing address"

## Description
Add information about default billing address next to the information about default shipping in address row
Reorganize the view and stand default shipping and default billing address above other addresses.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/789614/148387854-c184fbf7-0cc0-4eb3-9e07-8b3fce6b72fb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
