### PR TITLE
fix(theme): fix preselection of sort order when query param is available

### DIFF
--- a/packages/theme/pages/Category.vue
+++ b/packages/theme/pages/Category.vue
@@ -34,7 +34,7 @@
 
         <div class="navbar__sort desktop-only">
           <span class="navbar__label">{{ $t('Sort by') }}:</span>
-          <LazyHydrate on-interaction>
+          <LazyHydrate when-visible>
             <SfSelect
               :value="sortBy.selected"
               placeholder="Select sorting"
@@ -90,7 +90,7 @@
     <div class="main section">
       <div class="sidebar desktop-only">
         <LazyHydrate when-visible>
-          <CategorySidebarMenu
+          <category-sidebar-menu
             :no-fetch="true"
           />
         </LazyHydrate>
@@ -371,6 +371,7 @@ import { useAddToCart } from '~/helpers/cart/addToCart';
 
 // TODO(addToCart qty, horizontal): https://github.com/vuestorefront/storefront-ui/issues/1606
 export default defineComponent({
+  name: 'CategoryPage',
   components: {
     CategorySidebarMenu,
     SfButton,


### PR DESCRIPTION
## Description
Fix for #384 

## Related Issue
#384 

## Motivation and Context
Bugfix

## How Has This Been Tested?
Once filter is set, reload page and observe if sort order is populated

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
