### PR TITLE
fix: broken cart after placing order as guest

### DIFF
--- a/packages/composables/src/composables/useBilling/index.ts
+++ b/packages/composables/src/composables/useBilling/index.ts
@@ -49,7 +49,7 @@ const factoryParams: UseBillingParams<any, any> = {
       : ({
         address: {
           ...address,
-          street: [address.street, apartment, neighborhood, extra],
+          street: [address.street, apartment, neighborhood, extra].filter(Boolean),
         },
         same_as_shipping: sameAsShipping,
       });

--- a/packages/composables/src/composables/useShipping/index.ts
+++ b/packages/composables/src/composables/useShipping/index.ts
@@ -49,7 +49,7 @@ const factoryParams: UseShippingParams<any, any> = {
       : ({
         address: {
           ...address,
-          street: [address.street, apartment, neighborhood, extra].filter(Boolean), // remove unused attributes
+          street: [address.street, apartment, neighborhood, extra].filter(Boolean),
         },
       });
 

--- a/packages/composables/src/composables/useShipping/index.ts
+++ b/packages/composables/src/composables/useShipping/index.ts
@@ -49,7 +49,7 @@ const factoryParams: UseShippingParams<any, any> = {
       : ({
         address: {
           ...address,
-          street: [address.street, apartment, neighborhood, extra],
+          street: [address.street, apartment, neighborhood, extra].filter(Boolean), // remove unused attributes
         },
       });
 

--- a/packages/theme/pages/Checkout/UserAccount.vue
+++ b/packages/theme/pages/Checkout/UserAccount.vue
@@ -218,7 +218,7 @@ export default defineComponent({
       if (!isAuthenticated.value) {
         await (
           !createUserAccount.value
-            ? attachToCart({ user: form.value })
+            ? attachToCart({ email: form.value.email })
             : register({ user: form.value })
         );
       }

--- a/packages/theme/pages/Checkout/__tests__/UserAccount.spec.js
+++ b/packages/theme/pages/Checkout/__tests__/UserAccount.spec.js
@@ -94,13 +94,7 @@ describe('<UserAccount/>', () => {
     await waitFor(() => {
       expect(attachToCartMock).toHaveBeenCalledTimes(1);
       expect(attachToCartMock).toHaveBeenCalledWith({
-        user: {
-          email: 'james@bond.io',
-          firstname: 'James',
-          lastname: 'Bond',
-          password: '',
-          is_subscribed: false,
-        },
+        email: 'james@bond.io',
       });
     });
     expect(routerPushMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixed when a user wants to place an order as a guest.

## Description
Fix for #247 
The problem was that the guest email address was not set correctly. 
Also fixed when passing the "neighborhood" and "extra" param when setting the billing address and shipping address.
If the params are empty, they are filtered out
Updated tests

## Motivation and Context
Now a guest can place an order

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
