### PR TITLE
fix: revert "refactor(theme): enable the currency switcher on `TopBar.vue`"

### DIFF
--- a/packages/theme/components/TopBar.vue
+++ b/packages/theme/components/TopBar.vue
@@ -12,7 +12,13 @@
       </SfButton>
     </template>
     <template #right>
-      <CurrencySelector />
+      <!--
+      /**
+       * The currency switch is commented, until the Core package
+       * enables the switch of currency without returning to the browser one with i18n
+       */
+        <CurrencySelector />
+      -->
       <StoreSwitcher />
     </template>
   </SfTopBar>
@@ -20,12 +26,12 @@
 
 <script>
 import { SfButton, SfTopBar } from '@storefront-ui/vue';
-import CurrencySelector from './CurrencySelector';
+// import CurrencySelector from './CurrencySelector';
 import StoreSwitcher from './StoreSwitcher';
 
 export default {
   components: {
-    CurrencySelector,
+    // CurrencySelector,
     SfTopBar,
     SfButton,
     StoreSwitcher,

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -125,9 +125,7 @@ export default {
     ],
     defaultLocale: 'default',
     autoChangeCookie: {
-      currency: false,
       locale: false,
-      country: false,
     },
     lazy: true,
     seo: true,


### PR DESCRIPTION
Reverts vuestorefront/magento2#421 because it causes unexpected errors: 

```
Mateuszs-MacBook-Pro:~ mkoszutowski$ kubectl -n demo-magento2-canary-europe-west1-gcp-storefrontcloud-io logs vue-storefront-dc9fb84bd-wmgkz
yarn run v1.22.15
$ cd packages/theme && yarn start
$ nuxt start

 WARN  [Magento: Middleware Config] Not found any configuration file, will use the ENV variable or default configuration.

ℹ Middleware starting....
ℹ Loading integrations...
ℹ - Loading: magento @vue-storefront/magento-api/server
ℹ - Loading: magento extension: tokenExtension
✔ - Integration: magento loaded!
✔ Integrations loaded!
✔ Middleware created!
ℹ Modern bundles are detected. Modern mode (server) is enabled now.
ℹ Listening on: http://10.3.21.199:3000/

 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)


 ERROR  Currency code is required with currency style.

  at Number.toLocaleString (<anonymous>)
  at Cn.<anonymous> (server.js:26810:80)
  at Cn.$$state (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:29787)
  at N.i [as value] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:15152)
  at a.get [as currentCurrencySymbol] (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13551)
  at a.CurrencySelectorvue_type_template_id_48d7b47c_scoped_true_render (server.js:26663:381)
  at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12483
  at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:11840)
  at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:12454)
  at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)
```

