### PR TITLE
fix(minicart): fix resolving configurable variants data

### DIFF
--- a/packages/api-client/src/api/cart/cart.ts
+++ b/packages/api-client/src/api/cart/cart.ts
@@ -114,6 +114,12 @@ export default gql`
             configurable_product_option_value_uid
             value_label
           }
+          configured_variant {
+            sku
+            thumbnail {
+              url
+            }
+          }
         }
         ... on BundleCartItem {
           bundle_options {
@@ -177,4 +183,5 @@ export default gql`
         }
       }
     }
-  }`;
+  }
+`;

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -11,7 +11,7 @@ import {
   Cart,
   CartItem,
   Product,
-  SelectedShippingMethod,
+  SelectedShippingMethod, ConfigurableCartItem, ProductInterface,
 } from '@vue-storefront/magento-api';
 import productGetters from './productGetters';
 import { AgnosticPaymentMethod } from '../types';
@@ -133,6 +133,8 @@ export const getTotalItems = (cart: Cart): number => {
   return cart.total_quantity;
 };
 
+export const getConfiguredVariant = (product: ConfigurableCartItem): ProductInterface | {} => product?.configured_variant || {};
+
 // eslint-disable-next-line import/no-named-as-default-member
 export const getFormattedPrice = (price: number) => productGetters.getFormattedPrice(price);
 
@@ -196,6 +198,7 @@ const cartGetters: CartGetters = {
   getTotals,
   productHasSpecialPrice,
   getStockStatus,
+  getConfiguredVariant,
 };
 
 export default cartGetters;

--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -292,7 +292,10 @@ export default defineComponent({
     const { isAuthenticated } = useUser();
     const { send: sendNotification, notifications } = useUiNotification();
 
-    const products = computed(() => cartGetters.getItems(cart.value).filter(Boolean));
+    const products = computed(() => cartGetters
+      .getItems(cart.value)
+      .filter(Boolean)
+      .map((item) => ({ ...item, product: { ...item.product, ...item.configured_variant } })));
     const totals = computed(() => cartGetters.getTotals(cart.value));
     const totalItems = computed(() => cartGetters.getTotalItems(cart.value));
     const getAttributes = (product) => product.configurable_options || [];


### PR DESCRIPTION
## Description
For configurable products, some data were pulled from a parent which yield issues with the duplicated key in the list or the wrong image.

## Related Issue
#434 
#435 

## Motivation and Context
Bugfixing and improvement

## How Has This Been Tested?

1. Add a few variants of a configurable product to the cart
2. Observe that all variants have proper images
3. Check console if there is any duplicate key error

## Screenshots (if appropriate):

![Screenshot 2022-01-20 at 10 50 52](https://user-images.githubusercontent.com/16045377/150319993-aa3688eb-48b0-4e04-a4c9-8391db509bda.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
