### PR TITLE
fix(theme): fix customer account update data and password change functionality

### DIFF
--- a/packages/composables/src/composables/useUser/index.ts
+++ b/packages/composables/src/composables/useUser/index.ts
@@ -139,10 +139,8 @@ CustomerCreateInput
   changePassword: async (context: Context, params) => {
     Logger.debug('[Magento] changing user password');
     const { data, errors } = await context.$magento.api.changeCustomerPassword(params);
-
     if (errors) {
       Logger.error(errors);
-
       throw new Error(errors.map((e) => e.message).join(','));
     }
 

--- a/packages/theme/components/MyAccount/PasswordResetForm.vue
+++ b/packages/theme/components/MyAccount/PasswordResetForm.vue
@@ -101,10 +101,10 @@ export default defineComponent({
         resetValidationFn();
       };
 
-      const onError = () => {
+      const onError = (msg) => {
         sendNotification({
           id: Symbol('password_not_updated'),
-          message: 'It was not possible to update your password.',
+          message: msg,
           type: 'danger',
           icon: 'cross',
           persist: false,

--- a/packages/theme/pages/MyAccount/MyProfile.vue
+++ b/packages/theme/pages/MyAccount/MyProfile.vue
@@ -79,15 +79,15 @@ export default defineComponent({
       load,
       loading,
       updateUser,
+      error,
     } = useUser();
 
     const formHandler = async (fn, onComplete, onError) => {
-      try {
-        const data = await fn();
-        if (!data) throw new Error('API Error');
-        await onComplete(data);
-      } catch (error) {
-        onError(error);
+      await fn();
+      if (error.value.changePassword !== null) {
+        onError(error.value.changePassword);
+      } else {
+        onComplete();
       }
     };
 
@@ -100,13 +100,14 @@ export default defineComponent({
       onComplete,
       onError,
     );
+
     const updatePassword = ({
       form,
       onComplete,
       onError,
     }) => formHandler(async () => changePassword({
-      currentPassword: form.value.currentPassword,
-      newPassword: form.value.newPassword,
+      current: form.value.currentPassword,
+      new: form.value.newPassword,
     }), onComplete, onError);
 
     onSSR(async () => {


### PR DESCRIPTION
Previously error and success messages were not displayed and the change password action always
lead to an error, now either update data and password change are handled properly

## Description
- update packages/theme/pages/MyAccount/MyProfile.vue component to properly handle user data update actions.

## Related Issue
-

## Motivation and Context
bugfix

## How Has This Been Tested?

1. Log in as a customer
2. Go to your account details tab
3. Try to update your data or to change password (with a valid and invalid data)
4. Observe relevant messages and action outcome
5. Also try to change the password with an invalid current password input and observe the behavior

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
