### PR TITLE
bugfix: Show correct shipping method price in preview-cart and summary

### DIFF
--- a/packages/theme/components/Checkout/VsfShippingProvider.vue
+++ b/packages/theme/components/Checkout/VsfShippingProvider.vue
@@ -112,6 +112,7 @@ export default defineComponent({
     const { cart } = useCart();
     const {
       state,
+      save: saveShippingProvider,
       error: errorShippingProvider,
       loading: loadingShippingProvider,
       setState,
@@ -129,9 +130,14 @@ export default defineComponent({
      * Instead, specify the pickup_location_code attribute in the setShippingAddressesOnCart mutation.
      */
     const selectShippingMethod = async (method) => {
-      await setState({
+      const shippingData = {
         carrier_code: method.carrier_code,
         method_code: method.method_code,
+      };
+
+      setState(shippingData);
+      await saveShippingProvider({
+        shippingMethod: shippingData,
       });
     };
 


### PR DESCRIPTION
Bugfix for #451 

## Description
When selecting a shipping method, the price was only updated when going from the billing step to the payment step.
Now it's updated when selecting a shipping method.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Jan-24-2022 13-39-44](https://user-images.githubusercontent.com/789614/150784626-cb977901-9881-49ea-b1aa-4e9311087f37.gif)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
