### PR TITLE
fix(theme): fixed cms page loading

### DIFF
--- a/packages/theme/pages/Page.vue
+++ b/packages/theme/pages/Page.vue
@@ -47,7 +47,7 @@ export default defineComponent({
     const { params } = route.value;
 
     onSSR(async () => {
-      await loadContent(params.slug || props.identifier);
+      await loadContent({ identifier: params.slug || props.identifier });
       if (error?.value?.content) nuxtError({ statusCode: 404 });
     });
     return {


### PR DESCRIPTION
Fixed loading content for CMS pages.

## Description
There was a bug during load cms data from magento:
```
 ERROR  [VSF][error]:  [GraphQL error]: Message: "Page id/identifier should be specified, Location: [column: 3, line: 2], Path: cmsPage  
```

## Related Issue
#494 

## Motivation and Context
CMS pages and a Page route should work as excepted.

## How Has This Been Tested?
Tested on my local env manually.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
