### PR TITLE
fix(theme): orders history table - no order details button on mobile

### DIFF
--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -103,15 +103,8 @@
             </SfTableData>
             <SfTableData class="orders__view orders__element--right">
               <SfButton
-                data-cy="order-history-btn_download"
-                class="sf-button--text smartphone-only"
-                @click="downloadOrder(order)"
-              >
-                {{ $t('Download') }}
-              </SfButton>
-              <SfButton
                 data-cy="order-history-btn_view"
-                class="sf-button--text desktop-only"
+                class="sf-button--text"
                 @click="currentOrder = order"
               >
                 {{ $t('View details') }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removed the download option and made details button available on mobile.
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#301
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![sizzy-photo-studio-2022-01-26T174932 961Z](https://user-images.githubusercontent.com/72459310/151251180-018ee85d-38a8-4342-8d02-a4730e1286eb.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
