### PR TITLE
fix(theme): add html unescaping in HTMLContent component

### DIFF
--- a/packages/theme/components/HTMLContent.vue
+++ b/packages/theme/components/HTMLContent.vue
@@ -6,6 +6,7 @@
 </template>
 <script>
 import { defineComponent, computed } from '@nuxtjs/composition-api';
+import _unescape from 'lodash.unescape';
 import DOMPurify from 'isomorphic-dompurify';
 
 export default defineComponent({
@@ -15,11 +16,14 @@ export default defineComponent({
       type: String,
       default: 'div',
     },
-    content: String,
+    content: {
+      type: String,
+      default: '',
+    },
   },
   setup(props) {
     return {
-      sanitizedContent: computed(() => DOMPurify.sanitize(props.content)),
+      sanitizedContent: computed(() => _unescape(DOMPurify.sanitize(props.content))),
     };
   },
 });

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -48,6 +48,7 @@
     "isomorphic-dompurify": "^0.17.0",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2",
+    "lodash.unescape": "^4.0.1",
     "nuxt": "^2.15.8",
     "nuxt-i18n": "^6.28.0",
     "omit-deep": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13197,6 +13197,11 @@ lodash.throttle@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
   integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
 
+lodash.unescape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
+  integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
+
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"


### PR DESCRIPTION
## Description
- add lodash.unescape to handle escaped HTML from Magento

## Related Issue
#514 

## Motivation and Context
- bugfix

## How Has This Been Tested?
Visit pages:

- cms page
- product page
- any page with content from Magento 2
- to double-check, resave product with updated description to make an "escaped save" on the Magento side, then check that product in VSF

## Screenshots (if appropriate):
![Screenshot 2022-02-01 at 12 47 54](https://user-images.githubusercontent.com/16045377/151963176-aecfeb71-681b-489f-9c56-5dcd03f87b1d.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
