### PR TITLE
fix(theme): fix invalid customer address save action route push

### DIFF
--- a/packages/theme/components/MyAccount/AddressForm.vue
+++ b/packages/theme/components/MyAccount/AddressForm.vue
@@ -302,8 +302,9 @@ export default defineComponent({
     const regionInformation = computed(() => addressGetter.regionList(country.value));
 
     const submitForm = () => {
-      if (form.region.region_code) {
-        form.region.region_id = regionInformation.value.find((r) => r.abbreviation === form.region.region_code).id;
+      const regionId = regionInformation.value.find((r) => r.abbreviation === form.region.region_code)?.id;
+      if (regionId) {
+        form.region.region_id = regionId;
       }
 
       emit('submit', {

--- a/packages/theme/pages/MyAccount/AddressesDetails.vue
+++ b/packages/theme/pages/MyAccount/AddressesDetails.vue
@@ -142,7 +142,7 @@ export default defineComponent({
         const actionMethod = isNewAddress.value ? save : update;
         const data = await actionMethod({ address: form });
         await onComplete(data);
-        await router.push(`/my-account/${getTranslatedUrlAddress('Addresses details')}`);
+        await router.push(app.localePath(`/my-account/${getTranslatedUrlAddress('Addresses details')}`));
       } catch (error) {
         onError(error);
       }


### PR DESCRIPTION
## Description
save or update of address details in the customer account will no longer yield 404

## Related Issue
#548 

## Motivation and Context
-

## How Has This Been Tested?

1. Open home page on mobile device/view
2. Log in/Register as a customer
3. Navigate to My Account panel
4. Navigate to Adress Details subpage
5. Click "Add new address"
6. Fill the form and submit

## Screenshots (if appropriate):
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
