### PR TITLE
fix(theme): fix missing shipping address form on the checkout for a c…

### DIFF
--- a/packages/theme/pages/Checkout/Shipping.vue
+++ b/packages/theme/pages/Checkout/Shipping.vue
@@ -415,15 +415,13 @@ export default defineComponent({
       await Promise.all([
         loadCountries(),
         load(),
+        loadUserShipping(),
       ]);
 
       if (shippingDetails.value?.country_code) {
         await searchCountry({ id: shippingDetails.value.country_code });
       }
 
-      if (!userShipping.value?.addresses && isAuthenticated.value) {
-        await loadUserShipping();
-      }
       const shippingAddresses = userShippingGetters.getAddresses(userShipping.value);
 
       if (!shippingAddresses || shippingAddresses.length === 0) {
@@ -434,9 +432,7 @@ export default defineComponent({
       const hasEmptyShippingDetails = !shippingDetails.value || Object.keys(shippingDetails.value).length === 0;
       if (hasEmptyShippingDetails) {
         selectDefaultAddress();
-        return;
       }
-      canAddNewAddress.value = false;
     });
 
     return {


### PR DESCRIPTION
## Description
fix missing shipping address form on the checkout for a comming back customer

## Related Issue
#493 

## Motivation and Context
bugfix

## How Has This Been Tested?

1. Log in as a customer
2. Make sure that you have at lease one address configured for your account
3. Add something to the cart and visit checkout
4. Go to the shipping step do load default address
5. Log out
6. Add something to the cart and visit checkout as a guest
7. Go to the shipping step
8. Observe that shipping address form is in place

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
