### PR TITLE
refactor(theme): remove core _theme module

### DIFF
--- a/packages/theme/components/AppFooter.vue
+++ b/packages/theme/components/AppFooter.vue
@@ -1,0 +1,139 @@
+<template>
+  <SfFooter
+    :column="4"
+    multiple
+    class="footer"
+  >
+    <SfFooterColumn :title="$t('About us')">
+      <SfList>
+        <SfListItem
+          v-for="item in aboutUs"
+          :key="item"
+        >
+          <SfMenuItem
+            :label="$t(item)"
+          />
+        </SfListItem>
+      </SfList>
+    </SfFooterColumn>
+    <SfFooterColumn :title="$t('Departments')">
+      <SfList>
+        <SfListItem
+          v-for="item in departments"
+          :key="item"
+        >
+          <SfMenuItem
+            :label="$t(item)"
+          />
+        </SfListItem>
+      </SfList>
+    </SfFooterColumn>
+    <SfFooterColumn :title="$t('Help')">
+      <SfList>
+        <SfListItem
+          v-for="item in help"
+          :key="item"
+        >
+          <SfMenuItem
+            :label="$t(item)"
+          />
+        </SfListItem>
+      </SfList>
+    </SfFooterColumn>
+    <SfFooterColumn :title="$t('Payment & Delivery')">
+      <SfList>
+        <SfListItem
+          v-for="item in paymentsDelivery"
+          :key="item"
+        >
+          <SfMenuItem
+            :label="$t(item)"
+          />
+        </SfListItem>
+      </SfList>
+    </SfFooterColumn>
+    <SfFooterColumn title="Social">
+      <div class="footer__socials">
+        <SfImage
+          v-for="item in social"
+          :key="item"
+          class="footer__social-image"
+          :src="addBasePath('/icons/'+item+'.svg')"
+          :alt="item"
+          width="32"
+          height="32"
+        />
+      </div>
+    </SfFooterColumn>
+  </SfFooter>
+</template>
+
+<script>
+import {
+  SfFooter, SfList, SfImage, SfMenuItem,
+} from '@storefront-ui/vue';
+import { addBasePath } from '@vue-storefront/core';
+
+export default {
+  components: {
+    SfFooter,
+    SfList,
+    SfImage,
+    SfMenuItem,
+  },
+  setup() {
+    return {
+      addBasePath,
+    };
+  },
+  data() {
+    return {
+      aboutUs: ['Who we are', 'Quality in the details', 'Customer Reviews'],
+      departments: ['Women fashion', 'Men fashion', 'Kidswear', 'Home'],
+      help: ['Customer service', 'Size guide', 'Contact us'],
+      paymentsDelivery: ['Purchase terms', 'Guarantee'],
+      social: ['facebook', 'pinterest', 'google', 'twitter', 'youtube'],
+      isMobile: false,
+      desktopMin: 1024,
+    };
+  },
+};
+</script>
+
+<style lang="scss">
+
+.footer {
+  margin-bottom: 3.75rem;
+  @include for-desktop {
+    margin-bottom: 0;
+  }
+  &__socials {
+    display: flex;
+    justify-content: space-between;
+    margin: 0 auto var(--spacer-lg);
+    padding: var(--spacer-base) var(--spacer-xl);
+    @include for-desktop {
+      justify-content: flex-start;
+      padding: var(--spacer-xs) 0;
+      margin: 0 auto;
+    }
+  }
+  &__social-image {
+    margin: 0 var(--spacer-2xs) 0 0;
+  }
+}
+.sf-footer {
+  @include for-desktop {
+    border-top: var(--spacer-xs) solid var(--c-primary);
+    padding-bottom: 0;
+    margin-top: var(--spacer-2xl);
+  }
+  &__container {
+    margin: var(--spacer-sm);
+    @include for-desktop {
+      max-width: 69rem;
+      margin: 0 auto;
+    }
+  }
+}
+</style>

--- a/packages/theme/components/HTMLContent.vue
+++ b/packages/theme/components/HTMLContent.vue
@@ -1,13 +1,11 @@
 <template>
   <component
     :is="tag"
-    v-html="sanitizedContent"
+    v-html="$dompurify(content)"
   />
 </template>
 <script>
-import { defineComponent, computed } from '@nuxtjs/composition-api';
-import _unescape from 'lodash.unescape';
-import DOMPurify from 'isomorphic-dompurify';
+import { defineComponent } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   name: 'HTMLContent',
@@ -20,11 +18,6 @@ export default defineComponent({
       type: String,
       default: '',
     },
-  },
-  setup(props) {
-    return {
-      sanitizedContent: computed(() => _unescape(DOMPurify.sanitize(props.content))),
-    };
   },
 });
 </script>

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -77,22 +77,6 @@ export default () => {
           ],
         },
       }],
-      // @core-development-only-start
-      ['@vue-storefront/nuxt-theme', {
-        generate: {
-          replace: {
-            apiClient: '@vue-storefront/magento-api',
-            composables: '@vue-storefront/magento',
-          },
-        },
-        routes: false,
-      }],
-      // @core-development-only-end
-      /* project-only-start
-      ['@vue-storefront/nuxt-theme', {
-        routes: false,
-      }],
-      project-only-end */
       ['@vue-storefront/magento/nuxt', {
         i18n: {
           useNuxtI18nConfig: true,
@@ -218,13 +202,14 @@ export default () => {
       '~/plugins/token-expired',
       '~/plugins/i18n',
       '~/plugins/fcPlugin',
+      '~/plugins/dompurify',
     ],
     serverMiddleware: [
       '~/serverMiddleware/body-parser.js',
     ],
     router: {
       extendRoutes(routes) {
-        getRoutes(`${__dirname}/_theme`)
+        getRoutes()
           .forEach((route) => routes.unshift(route));
       },
     },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -38,7 +38,6 @@
     "@vue-storefront/magento": "1.0.0-rc.5.4",
     "@vue-storefront/middleware": "~2.5.4",
     "@vue-storefront/nuxt": "~2.5.4",
-    "@vue-storefront/nuxt-theme": "~2.5.4",
     "convict": "^6.2.1",
     "convict-format-with-validator": "^6.2.0",
     "cookie-universal-nuxt": "^2.1.5",

--- a/packages/theme/pages/Checkout/ThankYou.vue
+++ b/packages/theme/pages/Checkout/ThankYou.vue
@@ -1,0 +1,275 @@
+<template>
+  <div id="thank-you">
+    <SfCallToAction
+      v-e2e="'thank-you-banner'"
+      class="banner"
+      title="Thank you for your order!"
+      :image="{
+        mobile: addBasePath('/thankyou/bannerM.png'),
+        desktop: addBasePath('/thankyou/bannerD.png'),
+      }"
+    >
+      <template #description>
+        <div class="banner__order-number">
+          <span>{{ $t('Order No.') }}</span>
+          <strong>{{ orderNumber }}</strong>
+        </div>
+      </template>
+    </SfCallToAction>
+    <section class="section">
+      <div class="order">
+        <SfHeading
+          title="Your Purchase"
+          class="order__heading heading sf-heading--left"
+          :level="3"
+        />
+        <p class="order__paragraph paragraph">
+          {{ $t('Successful placed order') }}
+        </p>
+        <div class="order__contact">
+          <SfHeading
+            :level="6"
+            class="heading sf-heading--left sf-heading--no-underline"
+            title="Primary contacts for any questions"
+          />
+          <div class="contact">
+            <p class="contact__name">
+              {{ companyDetails.name }}
+            </p>
+            <p class="contact__street">
+              {{ companyDetails.street }}
+            </p>
+            <p class="contact__city">
+              {{ companyDetails.city }}
+            </p>
+            <p class="contact__email">
+              {{ companyDetails.email }}
+            </p>
+          </div>
+        </div>
+        <SfButton class="order__notifications-button button-size">
+          {{ $t('Allow order notifications') }}
+        </SfButton>
+      </div>
+      <div class="additional-info">
+        <div>
+          <SfHeading
+            title="Your Account"
+            class="heading sf-heading--left"
+            :level="3"
+          />
+          <p class="paragraph">
+            {{ $t('Info after order') }}
+          </p>
+        </div>
+        <div>
+          <SfHeading
+            title="What can we improve"
+            class="heading sf-heading--left"
+            :level="3"
+          />
+          <p class="paragraph">
+            {{ $t('Feedback') }}
+          </p>
+          <SfButton
+            class="feedback-button color-secondary sf-button--full-width button-size"
+          >
+            {{ $t('Send my feedback') }}
+          </SfButton>
+        </div>
+      </div>
+    </section>
+    <SfButton class="back-button color-secondary button-size">
+      {{ $t('Go back to shop') }}
+    </SfButton>
+  </div>
+</template>
+
+<script>
+import { SfHeading, SfButton, SfCallToAction } from '@storefront-ui/vue';
+import { ref } from '@nuxtjs/composition-api';
+import { addBasePath } from '@vue-storefront/core';
+
+export default {
+  components: {
+    SfHeading,
+    SfButton,
+    SfCallToAction,
+  },
+  setup(props, context) {
+    context.emit('changeStep', 4);
+
+    const companyDetails = ref({
+      name: 'Divante Headquarter',
+      street: 'St. Dmowskiego 17, 53-534',
+      city: 'Wroclaw, Poland',
+      email: 'demo@vuestorefront.io',
+    });
+    const orderNumber = ref('80932031-030-00');
+
+    return {
+      addBasePath,
+      companyDetails,
+      orderNumber,
+    };
+  },
+};
+</script>
+<style lang="scss" scoped>
+#thank-you {
+  box-sizing: border-box;
+  @include for-desktop {
+    max-width: 1272px;
+    padding: 0 var(--spacer-sm);
+    margin: 0 auto;
+  }
+}
+.heading {
+  --heading-padding: var(--spacer-base) 0;
+  @include for-desktop {
+    --heading-padding: var(--spacer-sm) 0 var(--spacer-xs) 0;
+  }
+}
+.paragraph {
+  margin: 0;
+  color: var(--c-link);
+  font: var(--font-weight--normal) var(--font-size--base) / 1.6
+    var(--font-family--primary);
+  @include for-desktop {
+    font-weight: var(--font-weight--light);
+    font-size: var(--font-size--sm);
+    margin-bottom: var(--spacer-lg);
+  }
+}
+.banner {
+  --call-to-action-color: var(--c-text);
+  --call-to-action-title-font-size: var(--h2-font-size);
+  --call-to-action-title-font-weight: var(--font-weight--semibold);
+  --call-to-action-text-container-width: 50%;
+  @include for-desktop {
+    margin: 0 0 var(--spacer-2xl) 0;
+  }
+  &__order-number {
+    display: flex;
+    flex-direction: column;
+    font: var(--font-weight--light) var(--font-size--sm) / 1.4
+      var(--font-family--primary);
+    @include for-desktop {
+      flex-direction: row;
+      font-size: var(--font-size--normal);
+    }
+  }
+}
+.section {
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  @include for-desktop {
+    flex-direction: row;
+    padding: 0;
+    background: var(--c-light);
+  }
+}
+.order {
+  background: var(--c-light);
+  padding-bottom: var(--spacer-sm);
+  @include for-desktop {
+    width: 100%;
+    padding: var(--spacer-xl) var(--spacer-xl) var(--spacer-2xl)
+      var(--spacer-2xl);
+  }
+  &__heading {
+    --heading-title-font-weight: var(--font-weight--bold);
+    @include for-desktop {
+      --heading-title-color: var(--c-link);
+      --heading-title-font-weight: var(--font-weight--swemibold);
+    }
+  }
+  &__heading,
+  &__paragraph,
+  &__contact {
+    @include for-mobile {
+      margin: 0;
+      padding-left: var(--spacer-sm);
+      padding-right: var(--spacer-sm);
+    }
+  }
+  &__contact {
+    padding-bottom: var(--spacer-base);
+    --heading-title-font-size: var(--font-size--lg);
+    --heading-title-font-weight: var(--font-weight--medium);
+    @include for-desktop {
+      --heading-title-font-size: var(--font-size--base);
+      --heading-title-font-weight: var(--font-weight--normal);
+      padding: 0 var(--spacer-sm);
+      border: 2px solid var(--c-white);
+      border-width: 2px 0 2px 0;
+    }
+  }
+  &__notifications-button {
+    --button-width: calc(100% - var(--spacer-lg));
+    margin: 0 auto;
+    @include for-desktop {
+      margin: var(--spacer-xl) 0 0 0;
+    }
+  }
+}
+.contact {
+  color: var(--c-dark-variant);
+  font: var(--font-weight--light) var(--font-size--base) / 1.6
+    var(--font-family--secondary);
+  @include for-desktop {
+    font-weight: var(--font-weight--normal);
+    font-size: var(--font-size--sm);
+  }
+  &__name,
+  &__street,
+  &__city {
+    margin: 0;
+  }
+  &__email {
+    margin: var(--spacer-sm) 0 0 0;
+    @include for-desktop {
+      margin-bottom: var(--spacer-sm);
+    }
+  }
+  &__name,
+  &__street,
+  &__city,
+  &__email {
+    font-size: var(--font-size--sm);
+  }
+}
+.additional-info {
+  --heading-title-font-weight: var(--font-weight--bold);
+  padding: 0 var(--spacer-sm);
+  @include for-desktop {
+    --heading-title-color: var(--c-link);
+    --heading-title-font-weight: var(--font-weight--semibold);
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: var(--spacer-xl) var(--spacer-xl) var(--spacer-2xl)
+      var(--spacer-2xl);
+  }
+}
+.feedback-button {
+  margin: var(--spacer-xl) 0 var(--spacer-sm) 0;
+  @include for-desktop {
+    margin: var(--spacer-base) 0 0 0;
+  }
+}
+.back-button {
+  --button-width: calc(100% - var(--spacer-lg));
+  margin: 0 auto var(--spacer-sm) auto;
+  @include for-desktop {
+    margin: var(--spacer-xl) auto;
+  }
+}
+.button-size {
+  @include for-desktop {
+    --button-width: 25rem;
+  }
+}
+</style>

--- a/packages/theme/plugins/dompurify.ts
+++ b/packages/theme/plugins/dompurify.ts
@@ -1,0 +1,12 @@
+import _unescape from 'lodash.unescape';
+import DOMPurify from 'isomorphic-dompurify';
+
+declare module 'vue/types/vue' {
+  interface Vue {
+    $dompurify(html: string): string;
+  }
+}
+
+export default (inject) => {
+  inject('dompurify', (html: string): string => _unescape(DOMPurify.sanitize(html)));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4517,16 +4517,6 @@
     cors "^2.8.5"
     express "^4.17.1"
 
-"@vue-storefront/nuxt-theme@~2.5.4":
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/@vue-storefront/nuxt-theme/-/nuxt-theme-2.5.4.tgz#7a8172836929afaf23825054d954414cf46cb859"
-  integrity sha512-X+y9eQ+2RSgx3nHUKMKiYUVP+016gxR9CgjD19DIM7Mezy6P6oos7Qbpkjm7yBObfHLl8bo1q8VSmxyVgntRaA==
-  dependencies:
-    ejs "^3.0.2"
-    lodash.debounce "^4.0.8"
-    lodash.merge "^4.6.2"
-    vue-lazy-hydration "^2.0.0-beta.4"
-
 "@vue-storefront/nuxt@~2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@vue-storefront/nuxt/-/nuxt-2.5.4.tgz#29d8fc368e66c7e46aed164654a92942208cc08b"
@@ -8640,7 +8630,7 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ejs@^3.0.2, ejs@^3.1.6:
+ejs@^3.1.6:
   version "3.1.6"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.6.tgz#5bfd0a0689743bb5268b3550cceeebbc1702822a"
   integrity sha512-9lt9Zse4hPucPkoP7FHDF0LQAlGyF9JVpnClFLFH3aSSbxmyoqINRpp/9wePWJTUl4KOQwRL72Iw3InHPDkoGw==


### PR DESCRIPTION
## Description
- remove core @vue-storefront/magento-theme module to save build weigh, module was no more necessary
but had an impact on the final build
- rework dompurify as a plugin to save bundle size
BREAKING CHANGE: - remove core @vue-storefront/magento-theme dependency

## Related Issue
-

## Motivation and Context
performance improvement

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
