### PR TITLE
refactor(theme): refactor useConfig composable

### DIFF
--- a/packages/composables/src/composables/useConfig/index.ts
+++ b/packages/composables/src/composables/useConfig/index.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated since version <version?>
+ *
+ * @see <add docs link>
+ */
 import { Context } from '@vue-storefront/core';
 import { StoreConfig } from '@vue-storefront/magento-api';
 import { useConfigFactory, UseConfigFactoryParams } from '../../factories/useConfigFactory';

--- a/packages/composables/src/composables/useExternalCheckout/index.ts
+++ b/packages/composables/src/composables/useExternalCheckout/index.ts
@@ -26,14 +26,14 @@ const factoryParams: UseExternalCheckoutFactoryParams = {
 
         } */
         window.location.replace(`${externalCheckout.cmsUrl}${externalCheckout.syncUrlPath}/token/${userToken}/cart/${cartToken}`);
-        return Promise.resolve('');
+        return '';
       }
 
       window.location.replace(`${externalCheckout.cmsUrl}${externalCheckout.syncUrlPath}/token//cart/${cartToken}`);
-      return Promise.resolve('');
+      return '';
     }
 
-    return Promise.resolve(params.baseUrl);
+    return params.baseUrl;
   },
 };
 

--- a/packages/composables/src/factories/useConfigFactory.ts
+++ b/packages/composables/src/factories/useConfigFactory.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated since version <version?>
+ *
+ * @see <add docs link>
+ */
 import { computed } from '@vue/composition-api';
 import {
   Context,

--- a/packages/composables/src/getters/storeConfigGetters.ts
+++ b/packages/composables/src/getters/storeConfigGetters.ts
@@ -1,4 +1,4 @@
-import { StoreConfig } from '@vue-storefront/magento-api';;
+import { StoreConfig } from '@vue-storefront/magento-api';
 
 const getCode = (config: StoreConfig) => config.store_code;
 const getTitle = (config: StoreConfig) => config.default_title;

--- a/packages/theme/components/StoreSwitcher.vue
+++ b/packages/theme/components/StoreSwitcher.vue
@@ -64,11 +64,11 @@
 
 <script>
 import {
-  useConfig,
   useStore,
   storeConfigGetters,
   storeGetters,
 } from '@vue-storefront/magento';
+
 import {
   SfButton,
   SfList,
@@ -80,6 +80,8 @@ import {
   computed,
   defineComponent,
 } from '@nuxtjs/composition-api';
+
+import { useConfig } from '~/composables';
 import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
 
 export default defineComponent({
@@ -92,9 +94,11 @@ export default defineComponent({
   },
   setup() {
     const {
+      loadConfig,
       config,
     } = useConfig();
 
+    loadConfig();
     const {
       stores,
       change: changeStore,

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -2,3 +2,4 @@ export { default as useUiHelpers } from './useUiHelpers';
 export { default as useUiNotification } from './useUiNotification';
 export { default as useUiState } from './useUiState';
 export { default as useImage } from './useImage';
+export { default as useConfig } from './useConfig';

--- a/packages/theme/composables/useConfig/index.ts
+++ b/packages/theme/composables/useConfig/index.ts
@@ -1,0 +1,35 @@
+import {
+  computed, ref, useContext,
+} from '@nuxtjs/composition-api';
+import { Logger } from '@vue-storefront/core';
+import { useConfigStore } from '~/stores/config';
+import { UseConfig } from '~/composables/useConfig/useConfig';
+
+const useConfig = (): UseConfig => {
+  const { app } = useContext();
+  const loading = ref(false);
+  const configStore = useConfigStore();
+
+  const loadConfig = async () => {
+    Logger.debug('useConfig/loadConfig');
+    loading.value = true;
+    try {
+      const { data } = await app.$vsf.$magento.api.storeConfig();
+      configStore.$patch({
+        value: data.storeConfig || {},
+      });
+    } catch (err) {
+      Logger.debug(err);
+    }
+
+    loading.value = false;
+  };
+
+  return {
+    config: computed(() => configStore.value),
+    loading,
+    loadConfig,
+  };
+};
+
+export default useConfig;

--- a/packages/theme/composables/useConfig/useConfig.d.ts
+++ b/packages/theme/composables/useConfig/useConfig.d.ts
@@ -1,0 +1,8 @@
+import { ComputedRef, Ref } from '@nuxtjs/composition-api';
+import { StoreConfig } from '@vue-storefront/magento';
+
+export type UseConfig = {
+  config: ComputedRef<StoreConfig>,
+  loading: Ref<boolean>,
+  loadConfig (): Promise<void>
+};

--- a/packages/theme/composables/useMagentoConfiguration.ts
+++ b/packages/theme/composables/useMagentoConfiguration.ts
@@ -1,5 +1,4 @@
 import {
-  useConfig,
   useCurrency,
   useStore,
   storeConfigGetters,
@@ -10,6 +9,7 @@ import {
 
 import { computed, ComputedRef, useContext } from '@nuxtjs/composition-api';
 import cookieNames from '~/enums/cookieNameEnum';
+import { useConfig } from '~/composables';
 
 type UseMagentoConfiguration = () => {
   currencies: ComputedRef<Currency>;

--- a/packages/theme/plugins/dompurify.ts
+++ b/packages/theme/plugins/dompurify.ts
@@ -7,6 +7,6 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default (inject) => {
+export default (_, inject) => {
   inject('dompurify', (html: string): string => _unescape(DOMPurify.sanitize(html)));
 };

--- a/packages/theme/stores/config.ts
+++ b/packages/theme/stores/config.ts
@@ -1,0 +1,10 @@
+import { defineStore } from 'pinia';
+import { StoreConfig } from '@vue-storefront/magento';
+
+const value: StoreConfig = {};
+
+export const useConfigStore = defineStore('storeConfig', {
+  state: () => ({
+    value,
+  }),
+});


### PR DESCRIPTION
## Description
    - mark composable useConfig as deprecated
    - move composable to theme module
    - rework composable to get rid of core dependency and to utilize Pinia store

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
