### PR TITLE
refactor: m2-154. refactor use store composable to use pinia store

### DIFF
--- a/packages/composables/src/composables/useStore/index.ts
+++ b/packages/composables/src/composables/useStore/index.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated since version <version?>
+ *
+ * @see <add docs link>
+ */
 import { Context } from '@vue-storefront/core';
 import { AvailableStores, StoreConfig } from '@vue-storefront/magento-api';
 import { useStoreFactory, UseStoreFactoryParams } from '../../factories/useStoreFactory';

--- a/packages/composables/src/factories/useStoreFactory.ts
+++ b/packages/composables/src/factories/useStoreFactory.ts
@@ -1,3 +1,8 @@
+/**
+ * @deprecated since version <version?>
+ *
+ * @see <add docs link>
+ */
 import { computed } from '@vue/composition-api';
 import {
   Context,

--- a/packages/theme/components/StoreSwitcher.vue
+++ b/packages/theme/components/StoreSwitcher.vue
@@ -64,7 +64,6 @@
 
 <script>
 import {
-  useStore,
   storeConfigGetters,
   storeGetters,
 } from '@vue-storefront/magento';
@@ -75,13 +74,14 @@ import {
   SfBottomModal,
   SfCharacteristic,
 } from '@storefront-ui/vue';
+
 import {
   ref,
   computed,
   defineComponent,
 } from '@nuxtjs/composition-api';
 
-import { useConfig } from '~/composables';
+import { useStore, useConfig } from '~/composables';
 import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
 
 export default defineComponent({
@@ -94,23 +94,22 @@ export default defineComponent({
   },
   setup() {
     const {
-      loadConfig,
       config,
     } = useConfig();
 
-    loadConfig();
     const {
       stores,
+      load: loadStores,
       change: changeStore,
     } = useStore();
 
     const { handleChanges } = useHandleChanges();
     const isLangModalOpen = ref(false);
 
-    const availableStores = computed(() => stores.value ?? []);
+    loadStores();
 
     return {
-      availableStores,
+      availableStores: stores,
       changeStore,
       handleChanges,
       isLangModalOpen,

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -3,4 +3,5 @@ export { default as useUiNotification } from './useUiNotification';
 export { default as useUiState } from './useUiState';
 export { default as useImage } from './useImage';
 export { default as useConfig } from './useConfig';
+export { default as useStore } from './useStore';
 export { default as useExternalCheckout } from './useExternalCheckout';

--- a/packages/theme/composables/useConfig/index.ts
+++ b/packages/theme/composables/useConfig/index.ts
@@ -15,8 +15,8 @@ const useConfig = (): UseConfig => {
     loading.value = true;
     try {
       const { data } = await app.$vsf.$magento.api.storeConfig();
-      configStore.$patch({
-        value: data.storeConfig || {},
+      configStore.$patch((state) => {
+        state.config = data.storeConfig || {};
       });
     } catch (err) {
       Logger.debug(err);
@@ -26,7 +26,7 @@ const useConfig = (): UseConfig => {
   };
 
   return {
-    config: computed(() => configStore.value),
+    config: computed(() => configStore.config),
     loading,
     loadConfig,
   };

--- a/packages/theme/composables/useStore/index.ts
+++ b/packages/theme/composables/useStore/index.ts
@@ -1,0 +1,62 @@
+import {
+  ref, computed, Ref, useContext,
+} from '@nuxtjs/composition-api';
+import { Context, Logger } from '@vue-storefront/core';
+import { AvailableStores, StoreConfig } from '@vue-storefront/magento-api';
+import { storeConfigGetters } from '@vue-storefront/magento';
+import { UseStoreInterface, UseStore, UseStoreErrors } from '~/composables/useStore/useStore';
+
+const useStore: UseStore<AvailableStores> = (): UseStoreInterface<AvailableStores> => {
+  const response: Ref<AvailableStores | null> = ref(null);
+  const loading: Ref<boolean> = ref(false);
+  const error: Ref<UseStoreErrors> = ref({ load: null, change: null });
+  const { app } = useContext();
+
+  const load = async (context: Context) => {
+    Logger.debug('useStoreFactory.load', context);
+
+    error.value.load = null;
+
+    try {
+      loading.value = true;
+      const { customQuery } = context;
+      response.value = await app.$vsf.$magento.api.availableStores(
+        { availableStores: 'availableStores', ...customQuery },
+      );
+    } catch (err) {
+      error.value.load = err;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  const change = (context: Context) => {
+    Logger.debug('useStoreFactory.change', context);
+
+    error.value.change = null;
+
+    try {
+      loading.value = true;
+      // @ts-ignore
+      const { store }: { store: StoreConfig } = context;
+
+      context.$magento.config.state.setStore(storeConfigGetters.getCode(store));
+      context.$magento.config.state.setCurrency(storeConfigGetters.getCurrency(store));
+      context.$magento.config.state.setLocale(storeConfigGetters.getCode(store));
+    } catch (err) {
+      error.value.change = err;
+    } finally {
+      loading.value = false;
+    }
+  };
+
+  return {
+    load,
+    change,
+    response: computed(() => response.value),
+    loading: computed(() => loading.value),
+    error: computed(() => error.value),
+  };
+};
+
+export default useStore;

--- a/packages/theme/composables/useStore/useStore.d.ts
+++ b/packages/theme/composables/useStore/useStore.d.ts
@@ -1,0 +1,12 @@
+import { UseStoreInterface as UseStoreInterfaceCore, UseStore as UseStoreCore } from '@vue-storefront/core';
+import { UseStoreFactoryChangeParamArguments } from '@vue-storefront/core/lib/src/types';
+
+export interface UseStoreInterface<STORES> extends Omit<UseStoreInterfaceCore<STORES>, 'change'> {
+  change(params: UseStoreFactoryChangeParamArguments): void;
+}
+
+export interface UseStore<STORES> {
+  (): UseStoreInterface<STORES>;
+}
+
+export { UseStoreErrors } from '@vue-storefront/core';

--- a/packages/theme/composables/useStore/useStore.d.ts
+++ b/packages/theme/composables/useStore/useStore.d.ts
@@ -1,12 +1,17 @@
-import { UseStoreInterface as UseStoreInterfaceCore, UseStore as UseStoreCore } from '@vue-storefront/core';
-import { UseStoreFactoryChangeParamArguments } from '@vue-storefront/core/lib/src/types';
+import { AvailableStores, StoreConfig } from '@vue-storefront/magento-api';
+import { Ref } from '@nuxtjs/composition-api';
+import { UseStoreErrors } from '@vue-storefront/core';
 
-export interface UseStoreInterface<STORES> extends Omit<UseStoreInterfaceCore<STORES>, 'change'> {
-  change(params: UseStoreFactoryChangeParamArguments): void;
+export interface UseStoreInterface {
+  change(store: StoreConfig): void;
+  load(customQuery: { availableStores: string }): Promise<void>;
+  stores: Ref<AvailableStores>,
+  loading: Ref<boolean>,
+  error: Ref<UseStoreErrors>,
 }
 
-export interface UseStore<STORES> {
-  (): UseStoreInterface<STORES>;
+export interface UseStore {
+  (): UseStoreInterface;
 }
 
 export { UseStoreErrors } from '@vue-storefront/core';

--- a/packages/theme/stores/config.ts
+++ b/packages/theme/stores/config.ts
@@ -1,10 +1,10 @@
 import { defineStore } from 'pinia';
 import { StoreConfig } from '@vue-storefront/magento';
 
-const value: StoreConfig = {};
+const config: StoreConfig = {};
 
 export const useConfigStore = defineStore('storeConfig', {
   state: () => ({
-    value,
+    config,
   }),
 });


### PR DESCRIPTION
## Description
refactor(theme): refactor useStore composable
    
  - mark useStore as deprecated in composables
  - add useStore composable in a theme module
  
  BREAKING CHANGE: rework useStore composable

## Related Issue
-

## Motivation and Context
-

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
