### PR TITLE
feat(theme): add conditional rendering for a store switcher and curre…

### DIFF
--- a/packages/theme/components/TopBar.vue
+++ b/packages/theme/components/TopBar.vue
@@ -12,23 +12,37 @@
       </SfButton>
     </template>
     <template #right>
-      <CurrencySelector />
-      <StoreSwitcher />
+      <CurrencySelector v-if="hasCurrencyToSelect" />
+      <StoreSwitcher v-if="hasStoresToSelect" />
     </template>
   </SfTopBar>
 </template>
 
 <script>
 import { SfButton, SfTopBar } from '@storefront-ui/vue';
-import CurrencySelector from './CurrencySelector';
-import StoreSwitcher from './StoreSwitcher';
+import { useCurrency, useStore } from '@vue-storefront/magento';
+import { computed } from '@nuxtjs/composition-api';
 
 export default {
   components: {
-    CurrencySelector,
+    CurrencySelector: () => import('./CurrencySelector'),
     SfTopBar,
     SfButton,
-    StoreSwitcher,
+    StoreSwitcher: () => import('./StoreSwitcher'),
+  },
+  setup() {
+    const {
+      stores,
+    } = useStore();
+
+    const {
+      currencies,
+    } = useCurrency();
+
+    return {
+      hasStoresToSelect: computed(() => stores.value.length > 1),
+      hasCurrencyToSelect: computed(() => currencies.value?.available_currency_codes?.length > 1),
+    };
   },
 };
 


### PR DESCRIPTION
## Description
- if there is less than 2 currencies/stores relevant switcher will be not displayed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
