### PR TITLE
refactor: introduced the useApi composable, refactored loading configuration

### DIFF
--- a/packages/composables/src/composables/useCart/index.ts
+++ b/packages/composables/src/composables/useCart/index.ts
@@ -388,7 +388,7 @@ const factoryParams: UseCartFactoryParams<Cart, CartItem, Product> = {
     const apiState = context.$magento.config.state;
     const { data } : any = await context.$magento.api.cartTotalQty(apiState.getCartId());
 
-    return data.cart.total_quantity;
+    return data?.cart?.total_quantity;
   },
 };
 

--- a/packages/composables/src/composables/useConfig/index.ts
+++ b/packages/composables/src/composables/useConfig/index.ts
@@ -1,4 +1,4 @@
-import { Context } from '@vue-storefront/core';
+import {Context, Logger} from '@vue-storefront/core';
 import { StoreConfig } from '@vue-storefront/magento-api';
 import { useConfigFactory, UseConfigFactoryParams } from '../../factories/useConfigFactory';
 import { UseConfig } from '../../types/composables';
@@ -6,6 +6,8 @@ import { UseConfig } from '../../types/composables';
 const factoryParams: UseConfigFactoryParams<StoreConfig> = {
   loadConfig: async (context: Context) => {
     const { data } = await context.$magento.api.storeConfig();
+
+    Logger.debug('[Magento] useConfig:loadConfig data', { data });
 
     return data.storeConfig || {};
   },

--- a/packages/composables/src/composables/useCustomQuery/index.ts
+++ b/packages/composables/src/composables/useCustomQuery/index.ts
@@ -4,6 +4,10 @@ import {
 } from '../../factories/useCustomQueryFactory';
 import { FetchPolicy } from '../../types';
 
+/**
+ * @deprecated Will be removed in 1.1.0 release
+ * @use @vue-storefront/magento-theme/composables/useApi instead
+ */
 export default useCustomQueryFactory({
   query: async (context: Context, {
     query,

--- a/packages/composables/src/factories/useCustomQueryFactory.ts
+++ b/packages/composables/src/factories/useCustomQueryFactory.ts
@@ -10,6 +10,10 @@ import { PlatformApi } from '@vue-storefront/core/lib/src/types';
 import { FetchPolicy } from '../types';
 import { UseCustomQuery } from '../types/composables';
 
+/**
+ * @deprecated Will be removed in 1.1.0 release
+ * @use @vue-storefront/magento-theme/composables/useApi instead
+ */
 export interface UseCustomQueryFactoryFactoryParams<QUERY_VARIABLES, QUERY_RETURN, API extends PlatformApi = any> extends FactoryParams<API> {
   query: (context: Context, {
     variables,

--- a/packages/theme/components/CurrencySelector.vue
+++ b/packages/theme/components/CurrencySelector.vue
@@ -6,82 +6,37 @@
     >
       {{ currentCurrencySymbol }}
     </SfButton>
-    <SfBottomModal
-      :is-open="isCurrencyModalOpen"
-      title="Choose Currency"
-      @click:close="isCurrencyModalOpen = !isCurrencyModalOpen"
-    >
-      <SfList
-        v-if="availableCurrencies.length > 1"
-      >
-        <SfListItem
-          v-for="currency in availableCurrencies"
-          :key="currency"
-        >
-          <a
-            href="/"
-            :class="selectedCurrency === currency ? 'container__currency--selected-label' : ''"
-            @click.prevent="handleChanges({
-              callback: () => changeCurrency({id: currency}),
-              redirect: false,
-              refresh: true
-            })"
-          >
-            <SfCharacteristic class="currency">
-              <template #title>
-                <span>{{ currency }}</span>
-              </template>
-            </SfCharacteristic>
-          </a>
-        </SfListItem>
-      </SfList>
-    </SfBottomModal>
+    <CurrenciesModal
+      v-if="isCurrencyModalOpen"
+      :is-modal-open="isCurrencyModalOpen"
+      :selected-currency="selectedCurrency"
+      @closeModal="isCurrencyModalOpen = false"
+    />
   </div>
 </template>
-
 <script>
 import {
-  useCurrency,
-} from '@vue-storefront/magento';
-import {
-  SfImage,
   SfButton,
-  SfList,
-  SfBottomModal,
-  SfCharacteristic,
 } from '@storefront-ui/vue';
 import {
   ref,
   computed,
   defineComponent,
-  onMounted,
 } from '@nuxtjs/composition-api';
 import { useMagentoConfiguration } from '~/composables/useMagentoConfiguration';
-import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
+import CurrenciesModal from './CurrencySelector/CurrenciesModal';
 
 export default defineComponent({
   name: 'CurrencySelector',
   components: {
+    CurrenciesModal,
     SfButton,
-    SfList,
-    SfBottomModal,
-    SfCharacteristic,
   },
   setup() {
     const {
       selectedCurrency,
       selectedLocale,
     } = useMagentoConfiguration();
-
-    /**
-     * The currency switch is commented, until the Core package
-     * enables the switch of currency without returning to the browser one with i18n
-     */
-    const {
-      currencies,
-      change: changeCurrency,
-      load: loadCurrencies
-    } = useCurrency();
 
     const currentCurrencySymbol = computed(() => {
       try {
@@ -101,21 +56,10 @@ export default defineComponent({
       }
     });
 
-    const { handleChanges } = useHandleChanges();
-
     const isCurrencyModalOpen = ref(false);
-
-    const availableCurrencies = computed(() => currencies.value?.available_currency_codes || []);
-
-    onMounted(() => {
-      loadCurrencies();
-    });
 
     return {
       currentCurrencySymbol,
-      availableCurrencies,
-      changeCurrency,
-      handleChanges,
       isCurrencyModalOpen,
       selectedCurrency,
       selectedLocale,
@@ -132,70 +76,28 @@ export default defineComponent({
   flex-wrap: nowrap;
   align-items: center;
   position: relative;
+}
 
-  .sf-bottom-modal {
-    z-index: 2;
-    left: 0;
-    @include for-desktop {
-      --bottom-modal-height: 100vh;
-    }
+.container__currency {
+  width: 20px;
+  --button-box-shadow: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  opacity: 0.5;
+  border: none;
+  margin-right: 15px;
+  background-color: white;
+  color: black;
+  border-radius: 50px;
+
+  &--selected-label {
+    font-weight: bold;
   }
 
-  .sf-bottom-modal::v-deep .sf-bottom-modal__close {
-    position: var(--circle-icon-position, absolute);
-    top: var(--spacer-xs);
-    right: var(--spacer-xs);
-  }
-
-  .sf-list {
-    .language {
-      padding: var(--spacer-sm);
-
-      &__flag {
-        margin-right: var(--spacer-sm);
-      }
-    }
-
-    @include for-desktop {
-      display: flex;
-    }
-  }
-
-  &__currency {
-    &--selected-label {
-      font-weight: bold;
-    }
-
-    width: 20px;
-    --button-box-shadow: none;
-    padding: 0px;
-    display: flex;
-    align-items: center;
-    opacity: 0.5;
-    border: none;
-    margin-right: 15px;
-    background-color: white;
-    color: black;
-    border-radius: 50px;
-
-    &:hover,
-    &--selected {
-      opacity: 1;
-    }
-
-    &--title {
-      --heading-title-font-weight: var(--font-weight--normal);
-      padding: var(
-              --bottom-modal-title-padding,
-              var(--spacer-sm) var(--spacer-lg)
-      );
-      color: var(--bottom-modal-title-color, var(--c-text));
-      text-align: var(--bottom-modal-title-text-align, center);
-      @include for-mobile {
-        --heading-title-font-size: var(--font-size--xs);
-        --heading-title-font-weight: var(--font-weight--bold);
-      }
-    }
+  &:hover,
+  &--selected {
+    opacity: 1;
   }
 }
 </style>

--- a/packages/theme/components/CurrencySelector.vue
+++ b/packages/theme/components/CurrencySelector.vue
@@ -54,6 +54,7 @@ import {
   ref,
   computed,
   defineComponent,
+  onMounted,
 } from '@nuxtjs/composition-api';
 import { useMagentoConfiguration } from '~/composables/useMagentoConfiguration';
 import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
@@ -61,7 +62,6 @@ import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
 export default defineComponent({
   name: 'CurrencySelector',
   components: {
-    SfImage,
     SfButton,
     SfList,
     SfBottomModal,
@@ -80,6 +80,7 @@ export default defineComponent({
     const {
       currencies,
       change: changeCurrency,
+      load: loadCurrencies
     } = useCurrency();
 
     const currentCurrencySymbol = computed(() => {
@@ -105,6 +106,10 @@ export default defineComponent({
     const isCurrencyModalOpen = ref(false);
 
     const availableCurrencies = computed(() => currencies.value?.available_currency_codes || []);
+
+    onMounted(() => {
+      loadCurrencies();
+    });
 
     return {
       currentCurrencySymbol,

--- a/packages/theme/components/CurrencySelector/CurrenciesModal.vue
+++ b/packages/theme/components/CurrencySelector/CurrenciesModal.vue
@@ -1,0 +1,126 @@
+<template>
+  <SfBottomModal
+    :is-open="isModalOpen"
+    title="Choose Currency"
+    @click:close="closeModal"
+  >
+    <SfList
+      v-if="availableCurrencies.length > 1"
+    >
+      <SfListItem
+        v-for="currency in availableCurrencies"
+        :key="currency"
+      >
+        <a
+          href="/"
+          :class="selectedCurrency === currency ? 'container__currency--selected-label' : ''"
+          @click.prevent="handleChanges({
+            callback: () => changeCurrency({id: currency}),
+            redirect: false,
+            refresh: true
+          })"
+        >
+          <SfCharacteristic class="currency">
+            <template #title>
+              <span>{{ currency }}</span>
+            </template>
+          </SfCharacteristic>
+        </a>
+      </SfListItem>
+    </SfList>
+  </SfBottomModal>
+</template>
+<script>
+import {
+  defineComponent, computed, onMounted,
+} from '@nuxtjs/composition-api';
+import {
+  SfList,
+  SfBottomModal,
+  SfCharacteristic,
+} from '@storefront-ui/vue';
+import {
+  useCurrency,
+} from '@vue-storefront/magento';
+import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
+
+export default defineComponent({
+  name: 'CurrenciesModal',
+  components: {
+    SfList,
+    SfBottomModal,
+    SfCharacteristic,
+  },
+  props: {
+    isModalOpen: Boolean,
+    selectedCurrency: String,
+  },
+  emits: ['closeModal'],
+  setup() {
+    const {
+      currencies,
+      change: changeCurrency,
+      load: loadCurrencies,
+    } = useCurrency('header-currency');
+
+    const { handleChanges } = useHandleChanges();
+
+    const availableCurrencies = computed(() => currencies.value?.available_currency_codes || []);
+
+    onMounted(() => {
+      if (currencies.value && currencies.value?.available_currency_codes) return;
+      loadCurrencies();
+    });
+
+    return {
+      changeCurrency,
+      handleChanges,
+      availableCurrencies,
+    };
+  },
+  methods: {
+    closeModal() {
+      this.$emit('closeModal');
+    },
+  },
+});
+</script>
+<style lang="scss" scoped>
+.sf-bottom-modal {
+  z-index: 2;
+  left: 0;
+  @include for-desktop {
+    --bottom-modal-height: 100vh;
+  }
+}
+.sf-bottom-modal::v-deep .sf-bottom-modal__close {
+  position: var(--circle-icon-position, absolute);
+  top: var(--spacer-xs);
+  right: var(--spacer-xs);
+}
+
+.sf-list {
+  .language {
+    padding: var(--spacer-sm);
+
+    &__flag {
+      margin-right: var(--spacer-sm);
+    }
+  }
+
+  @include for-desktop {
+    display: flex;
+  }
+}
+
+.container__currency {
+  &--selected-label {
+    font-weight: bold;
+  }
+
+  &:hover,
+  &--selected {
+    opacity: 1;
+  }
+}
+</style>

--- a/packages/theme/components/StoreSwitcher.vue
+++ b/packages/theme/components/StoreSwitcher.vue
@@ -79,6 +79,7 @@ import {
   ref,
   computed,
   defineComponent,
+  onMounted,
 } from '@nuxtjs/composition-api';
 import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
 
@@ -98,12 +99,17 @@ export default defineComponent({
     const {
       stores,
       change: changeStore,
+      load: loadStores,
     } = useStore();
 
     const { handleChanges } = useHandleChanges();
     const isLangModalOpen = ref(false);
 
     const availableStores = computed(() => stores.value ?? []);
+
+    onMounted(() => {
+      loadStores();
+    });
 
     return {
       availableStores,

--- a/packages/theme/components/StoreSwitcher.vue
+++ b/packages/theme/components/StoreSwitcher.vue
@@ -19,102 +19,50 @@
         </template>
       </SfCharacteristic>
     </SfButton>
-    <SfBottomModal
-      :is-open="isLangModalOpen"
-      :title="availableStores.length > 0 ? 'Change Store': ''"
-      @click:close="isLangModalOpen = !isLangModalOpen"
-    >
-      <SfList
-        v-if="availableStores.length > 1"
-      >
-        <SfListItem
-          v-for="store in availableStores"
-          :key="store.id"
-        >
-          <a
-            href="/"
-            class="container__store--link"
-            :class="storeGetters.getSelected(storeConfig, store) ? 'container__store--selected' : ''"
-            @click="handleChanges({
-              callback: () => changeStore(store),
-              redirect: false,
-              windowRefresh: true,
-            })"
-          >
-            <SfCharacteristic class="language">
-              <template #title>
-                <span>{{ storeConfigGetters.getName(store) }}</span>
-              </template>
-              <template #icon>
-                <nuxt-img
-                  :src="`/icons/langs/${storeConfigGetters.getLocale(store)}.webp`"
-                  width="20"
-                  height="20"
-                  alt="Flag"
-                  class="language__flag"
-                />
-              </template>
-            </SfCharacteristic>
-          </a>
-        </SfListItem>
-      </SfList>
-    </SfBottomModal>
+    <LazyHydrate when-visible>
+      <StoresModal
+        v-if="isLangModalOpen"
+        :store-config="storeConfig"
+        :is-lang-modal-open="isLangModalOpen"
+        @closeModal="isLangModalOpen = false"
+      />
+    </LazyHydrate>
   </div>
 </template>
 
 <script>
+import LazyHydrate from 'vue-lazy-hydration';
 import {
   useConfig,
-  useStore,
   storeConfigGetters,
   storeGetters,
 } from '@vue-storefront/magento';
 import {
   SfButton,
-  SfList,
-  SfBottomModal,
   SfCharacteristic,
 } from '@storefront-ui/vue';
 import {
   ref,
-  computed,
   defineComponent,
-  onMounted,
 } from '@nuxtjs/composition-api';
-import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
+import StoresModal from '~/components/StoreSwitcher/StoresModal.vue';
 
 export default defineComponent({
   name: 'StoreSwitcher',
   components: {
+    StoresModal,
     SfButton,
-    SfList,
-    SfBottomModal,
     SfCharacteristic,
+    LazyHydrate,
   },
   setup() {
     const {
       config,
     } = useConfig();
 
-    const {
-      stores,
-      change: changeStore,
-      load: loadStores,
-    } = useStore();
-
-    const { handleChanges } = useHandleChanges();
     const isLangModalOpen = ref(false);
 
-    const availableStores = computed(() => stores.value ?? []);
-
-    onMounted(() => {
-      loadStores();
-    });
-
     return {
-      availableStores,
-      changeStore,
-      handleChanges,
       isLangModalOpen,
       storeConfig: config,
       storeConfigGetters,
@@ -125,84 +73,30 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
+.language {
+  &__flag {
+    margin-right: var(--spacer-sm);
+  }
+}
 
-.container {
+.container__lang {
+  --button-box-shadow: none;
+  background: none;
+  padding: 0 5px;
   display: flex;
-  flex-wrap: nowrap;
   align-items: center;
-  position: relative;
+  opacity: 0.5;
+  border: none;
 
-  .sf-bottom-modal {
-    z-index: 2;
-    left: 0;
-    @include for-desktop {
-      --bottom-modal-height: 100vh;
-    }
+  &:hover,
+  &--selected {
+    opacity: 1;
   }
+}
 
-  .sf-bottom-modal::v-deep .sf-bottom-modal__close {
-    position: var(--circle-icon-position, absolute);
-    top: var(--spacer-xs);
-    right: var(--spacer-xs);
-  }
-
-  .language {
-    padding: var(--spacer-sm);
-
-    &__flag {
-      margin-right: var(--spacer-sm);
-    }
-  }
-
-  .sf-list {
-    @include for-desktop {
-      display: flex;
-    }
-  }
-
-  &__store {
-    &--selected {
-      font-weight: bold;
-    }
-  }
-
-  &__lang {
-    --button-box-shadow: none;
-    background: none;
-    padding: 0 5px;
-    display: flex;
-    align-items: center;
-    opacity: 0.5;
-    border: none;
-
-    &:hover,
-    &--selected {
-      opacity: 1;
-    }
-
-    &--title {
-      --heading-title-font-weight: var(--font-weight--normal);
-      padding: var(
-              --bottom-modal-title-padding,
-              var(--spacer-sm) var(--spacer-lg)
-      );
-      color: var(--bottom-modal-title-color, var(--c-text));
-      text-align: var(--bottom-modal-title-text-align, center);
-      @include for-mobile {
-        --heading-title-font-size: var(--font-size--xs);
-        --heading-title-font-weight: var(--font-weight--bold);
-      }
-    }
-  }
-
-  .sf-characteristic__text {
-    color: var(--bottom-modal-title-color, var(--c-text));
-  }
-
-  .store-switcher {
-    text-transform: capitalize;
-    color: var(--bottom-modal-title-color, var(--c-link));
-    font-size: var(--font-size--sm);
-  }
+.store-switcher {
+  text-transform: capitalize;
+  color: var(--bottom-modal-title-color, var(--c-link));
+  font-size: var(--font-size--sm);
 }
 </style>

--- a/packages/theme/components/StoreSwitcher/StoresModal.vue
+++ b/packages/theme/components/StoreSwitcher/StoresModal.vue
@@ -77,11 +77,12 @@ export default defineComponent({
       stores,
       change: changeStore,
       load: loadStores,
-    } = useStore();
+    } = useStore('header-stores');
 
     const availableStores = computed(() => stores.value ?? []);
 
     onMounted(() => {
+      if (stores.value && stores.value?.length) return;
       loadStores();
     });
 
@@ -95,11 +96,9 @@ export default defineComponent({
   },
   methods: {
     closeModal() {
-      console.log('close modal');
       this.$emit('closeModal');
     },
   },
-
 });
 </script>
 <style scoped lang="scss">

--- a/packages/theme/components/StoreSwitcher/StoresModal.vue
+++ b/packages/theme/components/StoreSwitcher/StoresModal.vue
@@ -1,0 +1,150 @@
+<template>
+  <SfBottomModal
+    :is-open="isLangModalOpen"
+    :title="availableStores.length > 0 ? 'Change Store': ''"
+    @click:close="closeModal"
+  >
+    <SfList
+      v-if="availableStores.length > 1"
+    >
+      <SfListItem
+        v-for="store in availableStores"
+        :key="store.id"
+      >
+        <a
+          href="/"
+          class="container__store--link"
+          :class="storeGetters.getSelected(storeConfig, store) ? 'container__store--selected' : ''"
+          @click="handleChanges({
+            callback: () => changeStore(store),
+            redirect: false,
+            windowRefresh: true,
+          })"
+        >
+          <SfCharacteristic class="language">
+            <template #title>
+              <span>{{ storeConfigGetters.getName(store) }}</span>
+            </template>
+            <template #icon>
+              <nuxt-img
+                :src="`/icons/langs/${storeConfigGetters.getLocale(store)}.webp`"
+                width="20"
+                height="20"
+                alt="Flag"
+                class="language__flag"
+              />
+            </template>
+          </SfCharacteristic>
+        </a>
+      </SfListItem>
+    </SfList>
+  </SfBottomModal>
+</template>
+<script>
+import {
+  defineComponent,
+  onMounted,
+  computed,
+} from '@nuxtjs/composition-api';
+import {
+  SfList,
+  SfBottomModal,
+  SfCharacteristic,
+} from '@storefront-ui/vue';
+import {
+  useStore,
+  storeConfigGetters,
+  storeGetters,
+} from '@vue-storefront/magento';
+import { useHandleChanges } from '~/helpers/magentoConfig/handleChanges';
+
+export default defineComponent({
+  name: 'StoresModal',
+  components: {
+    SfList,
+    SfBottomModal,
+    SfCharacteristic,
+  },
+  props: {
+    isLangModalOpen: Boolean,
+    storeConfig: Object,
+  },
+  emits: ['closeModal'],
+  setup() {
+    const { handleChanges } = useHandleChanges();
+
+    const {
+      stores,
+      change: changeStore,
+      load: loadStores,
+    } = useStore();
+
+    const availableStores = computed(() => stores.value ?? []);
+
+    onMounted(() => {
+      loadStores();
+    });
+
+    return {
+      storeGetters,
+      storeConfigGetters,
+      handleChanges,
+      availableStores,
+      changeStore,
+    };
+  },
+  methods: {
+    closeModal() {
+      console.log('close modal');
+      this.$emit('closeModal');
+    },
+  },
+
+});
+</script>
+<style scoped lang="scss">
+.container {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  position: relative;
+}
+
+.container__store {
+  &--selected {
+    font-weight: bold;
+  }
+}
+
+.sf-characteristic__text {
+  color: var(--bottom-modal-title-color, var(--c-text));
+}
+
+.sf-bottom-modal {
+  z-index: 2;
+  left: 0;
+  @include for-desktop {
+    --bottom-modal-height: 100vh;
+  }
+}
+
+.sf-bottom-modal::v-deep .sf-bottom-modal__close {
+  position: var(--circle-icon-position, absolute);
+  top: var(--spacer-xs);
+  right: var(--spacer-xs);
+}
+
+.language {
+  padding: var(--spacer-sm);
+
+  &__flag {
+    margin-right: var(--spacer-sm);
+  }
+}
+
+.sf-list {
+  @include for-desktop {
+    display: flex;
+  }
+}
+</style>

--- a/packages/theme/components/TopBar/checkStoresAndCurrency.gql.ts
+++ b/packages/theme/components/TopBar/checkStoresAndCurrency.gql.ts
@@ -1,0 +1,12 @@
+import { gql } from 'graphql-request';
+
+export default gql`
+  query getStoresAndCurrencies {
+      availableStores {
+        store_code
+      }
+    currency {
+      available_currency_codes
+    }
+  }
+`;

--- a/packages/theme/components/TopBar/index.vue
+++ b/packages/theme/components/TopBar/index.vue
@@ -20,28 +20,21 @@
 
 <script>
 import { SfButton, SfTopBar } from '@storefront-ui/vue';
-import { useCurrency, useStore } from '@vue-storefront/magento';
-import { computed } from '@nuxtjs/composition-api';
+import useTopBar from './useTopBar';
 
 export default {
   components: {
-    CurrencySelector: () => import('./CurrencySelector'),
+    CurrencySelector: () => import('../CurrencySelector'),
     SfTopBar,
     SfButton,
-    StoreSwitcher: () => import('./StoreSwitcher'),
+    StoreSwitcher: () => import('../StoreSwitcher'),
   },
   setup() {
-    const {
-      stores,
-    } = useStore();
-
-    const {
-      currencies,
-    } = useCurrency();
+    const { hasStoresToSelect, hasCurrencyToSelect } = useTopBar();
 
     return {
-      hasStoresToSelect: computed(() => stores.value.length > 1),
-      hasCurrencyToSelect: computed(() => currencies.value?.available_currency_codes?.length > 1),
+      hasStoresToSelect,
+      hasCurrencyToSelect,
     };
   },
 };

--- a/packages/theme/components/TopBar/useTopBar.ts
+++ b/packages/theme/components/TopBar/useTopBar.ts
@@ -1,0 +1,24 @@
+import { ref, onMounted } from '@nuxtjs/composition-api';
+
+import useApi from '~/composables/useApi';
+import checkStoresAndCurrencyQuery from './checkStoresAndCurrency.gql';
+
+export const useTopBar = () => {
+  const { query } = useApi();
+  const hasStoresToSelect = ref(null);
+  const hasCurrencyToSelect = ref(null);
+
+  onMounted(async () => {
+    const data = await query(checkStoresAndCurrencyQuery);
+
+    hasStoresToSelect.value = data?.availableStores?.length;
+    hasCurrencyToSelect.value = data?.currency?.available_currency_codes?.length > 1;
+  });
+
+  return {
+    hasStoresToSelect,
+    hasCurrencyToSelect,
+  };
+};
+
+export default useTopBar;

--- a/packages/theme/composables/useApi/index.ts
+++ b/packages/theme/composables/useApi/index.ts
@@ -1,0 +1,43 @@
+import { useContext } from '@nuxtjs/composition-api';
+import { request as graphQLRequest, GraphQLClient } from 'graphql-request';
+import cookieNames from '~/enums/cookieNameEnum';
+
+export const useApi = () => {
+  const { app } = useContext();
+  const customerToken = app.$cookies.get(cookieNames.customerCookieName);
+  const magentoConfig = app.$vsf.$magento.config;
+  const { useGETForQueries } = magentoConfig.customApolloHttpLinkOptions;
+  const defaultEndpoint = magentoConfig.magentoApiEndpoint as string;
+  const defaultHeaders = {
+    store: app.$cookies.get(cookieNames.storeCookieName),
+    authorization: undefined,
+  };
+
+  if (customerToken) {
+    defaultHeaders.authorization = `Bearer ${customerToken}`;
+  }
+
+  const query = (
+    document: string,
+    endpoint = defaultEndpoint,
+    variables = null,
+    requestHeaders = defaultHeaders,
+  ) => new GraphQLClient(endpoint, {
+    method: useGETForQueries ? 'GET' : 'POST',
+    headers: requestHeaders,
+  }).request(document, variables);
+
+  const mutate = (
+    document: string,
+    endpoint = defaultEndpoint,
+    variables = null,
+    requestHeaders = defaultHeaders,
+  ) => graphQLRequest(endpoint, document, variables, requestHeaders);
+
+  return {
+    query,
+    mutate,
+  };
+};
+
+export default useApi;

--- a/packages/theme/composables/useMagentoConfiguration.ts
+++ b/packages/theme/composables/useMagentoConfiguration.ts
@@ -1,7 +1,5 @@
 import {
   useConfig,
-  useCurrency,
-  useStore,
   storeConfigGetters,
   Currency,
   AvailableStores,
@@ -27,16 +25,6 @@ export const useMagentoConfiguration: UseMagentoConfiguration = () => {
     config: storeConfig,
     loadConfig,
   } = useConfig();
-
-  const {
-    stores,
-    load: loadStores,
-  } = useStore();
-
-  const {
-    currencies,
-    load: loadCurrencies,
-  } = useCurrency();
 
   const selectedCurrency = computed<string | undefined>(() => app.$cookies.get(cookieNames.currencyCookieName));
 
@@ -73,14 +61,9 @@ export const useMagentoConfiguration: UseMagentoConfiguration = () => {
 
       return true;
     });
-
-    loadStores();
-    loadCurrencies();
   };
 
   return {
-    currencies,
-    stores,
     storeConfig,
     selectedCurrency,
     selectedLocale,

--- a/packages/theme/layouts/default.vue
+++ b/packages/theme/layouts/default.vue
@@ -33,7 +33,7 @@ import useUiState from '~/composables/useUiState.ts';
 import { useMagentoConfiguration } from '~/composables/useMagentoConfiguration';
 import AppHeader from '~/components/AppHeader.vue';
 import BottomNavigation from '~/components/BottomNavigation.vue';
-import TopBar from '~/components/TopBar.vue';
+import TopBar from '~/components/TopBar';
 
 export default defineComponent({
   name: 'DefaultLayout',

--- a/packages/theme/layouts/default.vue
+++ b/packages/theme/layouts/default.vue
@@ -22,7 +22,9 @@
 
 <script>
 import LazyHydrate from 'vue-lazy-hydration';
-import { useRoute, defineComponent, onMounted } from '@nuxtjs/composition-api';
+import {
+  useRoute, defineComponent, onMounted, useAsync,
+} from '@nuxtjs/composition-api';
 import {
   useUser,
 } from '@vue-storefront/magento';
@@ -54,8 +56,11 @@ export default defineComponent({
     const { loadConfiguration } = useMagentoConfiguration();
     const { isCartSidebarOpen } = useUiState();
 
-    onMounted(() => {
+    useAsync(() => {
       loadConfiguration();
+    });
+
+    onMounted(() => {
       loadUser();
     });
 

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -26,6 +26,7 @@ module.exports = {
           useGETForQueries: false,
         },
         magentoBaseUrl: config.get('magentoBaseUrl'),
+        magentoApiEndpoint: config.get('magentoGraphQl'),
         imageProvider: config.get('imageProvider'),
         recaptcha: {
           isEnabled: config.get('recaptchaEnabled'),

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -16,6 +16,8 @@ const {
         facets,
         magentoBaseUrl,
         imageProvider,
+        magentoApiEndpoint,
+        customApolloHttpLinkOptions,
       },
     },
   },
@@ -87,6 +89,8 @@ export default () => {
         facets,
         magentoBaseUrl,
         imageProvider,
+        magentoApiEndpoint,
+        customApolloHttpLinkOptions
       }],
       '@nuxt/image',
     ],

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -43,6 +43,7 @@
     "cookie-universal-nuxt": "^2.1.5",
     "deepdash": "^5.3.9",
     "dotenv": "^16.0.0",
+    "graphql-request": "^4.0.0",
     "isomorphic-dompurify": "^0.18.0",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10378,6 +10378,15 @@ graphql-request@^3.3.0:
     extract-files "^9.0.0"
     form-data "^3.0.0"
 
+graphql-request@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.0.0.tgz#5e4361d33df1a95ccd7ad23a8ebb6bbca9d5622f"
+  integrity sha512-cdqQLCXlBGkaLdkLYRl4LtkwaZU6TfpE7/tnUQFl3wXfUPWN74Ov+Q61VuIh+AltS789YfGB6whghmCmeXLvTw==
+  dependencies:
+    cross-fetch "^3.0.6"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
+
 graphql-sse@^1.0.1:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/graphql-sse/-/graphql-sse-1.0.6.tgz#4f98e0a06f2020542ed054399116108491263224"


### PR DESCRIPTION
## Description
💅 Refactors

`composables`
- fixed type error in the `useCart` composables that appeared when cart was empty
- added debug log in the `useConfig` loadConfig method in the `useConfig` composable
- made the `useCustomQuery` composable depraacated

`theme`
- refactored the `useMagentoContiguration` composables to load only config
- added StoresModal component and moved loading stores there
- added CurrenciesModal component and moved loading currencies there
- make those components lazy-loaded
- refactored styles of the `CurrencySelector` and  the `StoreSwitcher` components
- refactored the `TobBar` component, moved all business logic to the `useTopBar` composable

🚀 Features

`theme`
- added the `useApi` composable (which replaces the `useCustomQuery` composable) and the possibility to run GraphQL requests without using composables

🏡 Chore

`theme`
- added `graphql-request` lightweight GraphQL client

## Motivation and Context

### Performance
First of all, we want to reduce main thread working but make components lazy laded and move composables execution to components that are not rendered on page load. 

In this case:
1. `useConfig` composable loads data when user clicks on StoreSwitcher and opens stores modal
2. `useCurrency`composable load currency data when user click on currency switcher and opens currencies modal

### State management
Until now we were using the apiClient and composables to load every data. 

On the one hand, composables produce singletons and allow to use of data in different places. On the other hand, there are many cases when we don't want to keep data globally and use those mechanisms that are redundant and cause some performance issues when the page is loading. 

In addition, API defined in APiClient typically gets a lot of data that is not necessary for specific situations. For example, `storeConfig` query gets all config objects from Magento, but on page load, we need only a few properties. 

To avoid over-fetching we should use small queries. In this case, the query looks like this: 
```
query getStoresAndCurrencies {
      availableStores {
        store_code
      }
    currency {
      available_currency_codes
    }
  }
```

To do so we added the possibility to execute queries and mutations directly from the app. 
- operations fired in the `onMounted` hooks are fired on client-side
- operations fired in the `useAsync`, or `useFetch` are fired on the server-side

#### Bussiness logic in components
Adding business logic in components makes components hard to extend so the new approach assumes that components with business logic use compostable that returns all necessary things like methods, computed values, etc. 

Take a look at the example
```
<template>
<!-- content here --> 
</template>

<script>
import { SfButton, SfTopBar } from '@storefront-ui/vue';
import useTopBar from './useTopBar';

export default {
  components: {
    CurrencySelector: () => import('../CurrencySelector'),
    SfTopBar,
    SfButton,
    StoreSwitcher: () => import('../StoreSwitcher'),
  },
  setup() {
    const { hasStoresToSelect, hasCurrencyToSelect } = useTopBar();

    return {
      hasStoresToSelect,
      hasCurrencyToSelect,
    };
  },
};

</script>
<style lang="scss" scoped>
// styles here
</style>
```

The `setup` function returns business logic from the `useTopBar` composable. In fact, it can look like this: 
```
 setup() {
    return ...useTopBar();
  },
```
but in my opinion, the first example is more readable. 

Thanks to that, business logic is separated from visual representation, and it's a good first step to provide an extensibility framework in the future

#### Vuex or Pinia stores
This approach allows developers to add an additional building block and use [Vuex](https://vuex.vuejs.org/) or [Pinia](https://pinia.vuejs.org/) store for state management instead of using sharedRefs. This is not implemented yet, but I wanted to open a discussion. 

#### Requesting other APIs
The `useApi` composable allow making a request to other endpoints that Magento endpoint so this adds some flexibility and additional options to integrate with other services. 


#### Note: CORS configuration
Magento does not allow to make requests to GraphQL API directly from the browser, and additional CORS configuration is needed on the Magento side. This [open-source module](https://github.com/graycoreio/magento2-cors) allows to properly configure CORS.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
