### PR TITLE
perf(theme): prevent loading unnecessary data on a mobile device in A…

### DIFF
--- a/packages/theme/components/Navigation/HeaderNavigationItem.vue
+++ b/packages/theme/components/Navigation/HeaderNavigationItem.vue
@@ -1,0 +1,37 @@
+<template>
+  <div class="sf-header-navigation-item">
+    <div class="sf-header-navigation-item__item sf-header-navigation-item__item--desktop">
+      <slot name="desktop-navigation-item">
+        <SfLink
+          class="sf-header-navigation-item__link"
+          :link="link"
+        >
+          {{
+            label
+          }}
+        </SfLink>
+      </slot>
+      <slot />
+    </div>
+  </div>
+</template>
+<script>
+import { SfLink } from '@storefront-ui/vue';
+
+export default {
+  name: 'HeaderNavigationItem',
+  components: {
+    SfLink,
+  },
+  props: {
+    label: {
+      type: String,
+      default: '',
+    },
+    link: {
+      type: [String, Object],
+      default: '',
+    },
+  },
+};
+</script>

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -54,6 +54,9 @@ export default () => {
       ],
     },
     loading: { color: '#fff' },
+    device: {
+      refreshOnResize: true,
+    },
     buildModules: [
       // to core
       '@nuxtjs/composition-api/module',
@@ -61,6 +64,7 @@ export default () => {
       '@nuxtjs/google-fonts',
       '@nuxtjs/pwa',
       '@nuxtjs/style-resources',
+      '@nuxtjs/device',
       ['@vue-storefront/nuxt', {
         // @core-development-only-start
         coreDevelopment: true,
@@ -90,7 +94,7 @@ export default () => {
         magentoBaseUrl,
         imageProvider,
         magentoApiEndpoint,
-        customApolloHttpLinkOptions
+        customApolloHttpLinkOptions,
       }],
       '@nuxt/image',
     ],

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -61,6 +61,7 @@
     "@babel/core": "^7.16.12",
     "@nuxt/types": "latest",
     "@nuxt/typescript-build": "latest",
+    "@nuxtjs/device": "^2.1.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/user-event": "^13.5.0",
     "@testing-library/vue": "^5.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3190,6 +3190,13 @@
     unplugin-vue2-script-setup "^0.7.3"
     upath "^2.0.1"
 
+"@nuxtjs/device@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@nuxtjs/device/-/device-2.1.0.tgz#552c668b2d82dc982d18429845777c19d48d87d6"
+  integrity sha512-TYBdt1w2bmCCWp+MhgcBATZtqyUBi3nSdNpcLGILw5USLwCsC/yZtIkq9YisuEzuRnod9w/RZpoE80MxLftEuA==
+  dependencies:
+    defu "^3.2.2"
+
 "@nuxtjs/google-fonts@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@nuxtjs/google-fonts/-/google-fonts-1.3.0.tgz#36cefee4aef4f8b772180c7ed7cc902f02f585c4"


### PR DESCRIPTION
## Description
prevent loading unnecessary data on a mobile device in AppHeader component

- add @nuxtjs/device package to recognize used device
- remove the mobile observer from header and replace it with device recognition tool
- navigation is now lazy-loaded, categories required for navigation are not loaded at all on
mobile devices

## Related Issue
-

## Motivation and Context
-

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
