### PR TITLE
fix(theme): clear login modal reset password data when modal is closed

### DIFF
--- a/packages/theme/components/LoginModal.vue
+++ b/packages/theme/components/LoginModal.vue
@@ -390,6 +390,7 @@ export default defineComponent({
       resetErrorValues();
       isForgotten.value = value;
       isLogin.value = !value;
+      isThankYouAfterForgotten.value = value;
     };
 
     const closeModal = () => {


### PR DESCRIPTION
## Description
clear login modal reset password data when modal is closed

## Related Issue
#586 

## Motivation and Context
bugfix

## How Has This Been Tested?

1. Open LoginModal
2. Click over Forgotten password? and Reset Password
3. Open LoginModal Again and click for Register.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
