### PR TITLE
fix: search customer is not being moved to product details page

### DIFF
--- a/packages/theme/components/Header/SearchBar/SearchBar.vue
+++ b/packages/theme/components/Header/SearchBar/SearchBar.vue
@@ -160,8 +160,9 @@ export default defineComponent({
       emit('SearchBar:result', result.value);
     }, 1000);
 
-    watch(route, (event) => {
-      closeSearch(event);
+    watch(route, () => {
+      hideSearch();
+      term.value = '';
     });
 
     return {

--- a/packages/theme/components/Header/SearchBar/SearchBar.vue
+++ b/packages/theme/components/Header/SearchBar/SearchBar.vue
@@ -51,7 +51,7 @@
 <script>
 import { SfButton, SfSearchBar } from '@storefront-ui/vue';
 import { defineComponent, ref } from '@nuxtjs/composition-api';
-import { clickOutside } from '@storefront-ui/vue/src/utilities/directives/click-outside/click-outside-directive.js';
+import { clickOutside } from '~/utilities/directives/click-outside/click-outside-directive.js';
 import SvgImage from '~/components/General/SvgImage.vue';
 
 import debounce from 'lodash.debounce';
@@ -60,6 +60,7 @@ import {
   useCategorySearch,
   useFacet,
 } from '@vue-storefront/magento';
+import { watch, useRoute } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   name: 'SearchBar',
@@ -83,6 +84,8 @@ export default defineComponent({
     const term = ref('');
     const isSearchOpen = ref(false);
     const result = ref(null);
+
+    const route = useRoute()
 
     const {
       result: searchResult,
@@ -123,9 +126,17 @@ export default defineComponent({
       }
     };
 
-    const closeSearch = () => {
-      hideSearch();
-      term.value = '';
+    const closeSearch = (event) => {
+      if (document) {
+        const searchResultsEl = document.getElementsByClassName('search');
+        if (!searchResultsEl[0].contains(event.target)) {
+          hideSearch();
+          term.value = '';
+        }
+      } else {
+        hideSearch();
+        term.value = '';
+      }
     };
 
     const handleSearch = debounce(async (paramValue) => {
@@ -148,6 +159,10 @@ export default defineComponent({
 
       emit('SearchBar:result', result.value);
     }, 1000);
+
+    watch(route, (event) => {
+      closeSearch(event);
+    });
 
     return {
       closeSearch,

--- a/packages/theme/components/Header/SearchBar/SearchBar.vue
+++ b/packages/theme/components/Header/SearchBar/SearchBar.vue
@@ -177,3 +177,11 @@ export default defineComponent({
 });
 
 </script>
+
+<style lang="scss" scoped>
+.sf-search-bar__button {
+  position: relative;
+  right: 20px;
+  bottom: 0;
+}
+</style>

--- a/packages/theme/utilities/directives/click-outside/click-outside-directive.js
+++ b/packages/theme/utilities/directives/click-outside/click-outside-directive.js
@@ -1,0 +1,19 @@
+export const clickOutside = {
+  bind(el, binding) {
+    binding.name = "click-outside";
+    const closeHandler = binding.value;
+    el._outsideClickHandler = function (event) {
+      if (!el.contains(event.target)) {
+        event.stopPropagation();
+        closeHandler(event, el);
+      }
+    };
+    document.addEventListener("mousedown", el._outsideClickHandler);
+    document.addEventListener("touchstart", el._outsideClickHandler);
+  },
+  unbind(el) {
+    document.removeEventListener("mousedown", el._outsideClickHandler);
+    document.removeEventListener("touchstart", el._outsideClickHandler);
+    el._outsideClickHandler = null;
+  },
+};


### PR DESCRIPTION
Fix for: #625 

## Description
There is a directive active "click-outside" of an element. This was available on only the search-input field. So when you click on something else than the input-field, the search results are removed before the routing can take place.
This issue is fixed now. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
