### PR TITLE
feat(api-client): improve performance of node HTTP calls

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -35,7 +35,8 @@
     "graphql": "^16.3.0",
     "graphql-tag": "^2.12.6",
     "isomorphic-fetch": "^3.0.0",
-    "dotenv": "^15.0.0"
+    "dotenv": "^15.0.0",
+    "agentkeepalive": "^4.2.1"
   },
   "devDependencies": {
     "@types/isomorphic-fetch": "^0.0.35",

--- a/packages/api-client/src/helpers/magentoLink/graphQl.ts
+++ b/packages/api-client/src/helpers/magentoLink/graphQl.ts
@@ -11,10 +11,14 @@ import { Logger } from '@vue-storefront/core';
 import { onError } from '@apollo/client/link/error';
 import { RetryLink } from '@apollo/client/link/retry';
 import { setContext } from '@apollo/client/link/context';
+import AgentKeepAlive from 'agentkeepalive';
 import { handleRetry } from './linkHandlers';
 import { Config } from '../../types/setup';
 import possibleTypes from '../../types/possibleTypes.json';
 import standardURL from '../url/standardURL';
+
+const { HttpsAgent } = AgentKeepAlive;
+const agent = new HttpsAgent();
 
 const createErrorHandler = () => onError(({
   graphQLErrors,
@@ -60,6 +64,9 @@ export const apolloLinkFactory = (settings: Config, handlers?: {
     uri: settings.api,
     // @ts-ignore
     fetch: (url, options) => fetch(standardURL(url), options),
+    fetchOptions: {
+      agent,
+    },
     ...settings.customApolloHttpLinkOptions,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5008,7 +5008,7 @@ agent-base@6, agent-base@^6.0.0, agent-base@^6.0.2:
   dependencies:
     debug "4"
 
-agentkeepalive@^4.1.3, agentkeepalive@^4.2.0:
+agentkeepalive@^4.1.3, agentkeepalive@^4.2.0, agentkeepalive@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.2.1.tgz#a7975cbb9f83b367f06c90cc51ff28fe7d499717"
   integrity sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

## Related Issue
Resolve https://github.com/vuestorefront/magento2/issues/735

## Motivation and Context
I found that every call made by VSF was slower than an API Client like Postman for example. After a few research i found that we are losing time to make a connection ( HTTPS round trip and so on... ).

## How Has This Been Tested?
- Home/Product/Categories/MyAccount pages have been tested.
- Add to cart, remove, update.
- Login/Logout

## Screenshots (if appropriate):

<img width="1504" alt="Capture d’écran 2022-03-15 à 08 52 33" src="https://user-images.githubusercontent.com/16859411/158333021-a1692fa4-2267-4115-8c26-1c30f527f9a0.png">
<img width="1413" alt="Capture d’écran 2022-03-15 à 08 49 19" src="https://user-images.githubusercontent.com/16859411/158333032-6f334c4f-53d2-4f20-bb52-f9a558cb3c7c.png">

:warning: this is on my local Machine, on production we can expect 10 to 30% improvement i think.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
