### PR TITLE
fix(composables): revert getters

### DIFF
--- a/packages/composables/src/getters/_utils.ts
+++ b/packages/composables/src/getters/_utils.ts
@@ -1,0 +1,30 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { AgnosticAttribute } from '@vue-storefront/core';
+import { Product } from '@vue-storefront/magento-api';
+
+export const getAttributeValue = (attribute) => attribute.values;
+
+export const formatAttributeList = (attributes): AgnosticAttribute[] => attributes.map((attr) => {
+  const attrValue = getAttributeValue(attr);
+  return {
+    name: attr.attribute_code,
+    value: attrValue,
+    label: attr.label,
+  };
+});
+
+export const getVariantByAttributes = (products: Product[], attributes: any): Product => {
+  if (!products || products.length === 0) {
+    return null;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const configurationKeys = Object.keys(attributes);
+
+  // @ts-ignore
+  return products[0].configurable_children.find((product) => configurationKeys
+    // @ts-ignore
+    .every((attrName) => product[attrName] && product[attrName] === attributes[attrName])) || products[0].configurable_children[0];
+};

--- a/packages/composables/src/getters/addressGetter.ts
+++ b/packages/composables/src/getters/addressGetter.ts
@@ -1,0 +1,33 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { Countries, Country } from '@vue-storefront/magento-api';
+import { AddressGetter } from '../types';
+
+const countriesList: AddressGetter['countriesList'] = (countries: Countries[]) => countries
+  .filter((c) => c.id && c.full_name_english && c.full_name_locale)
+  .map((c) => ({
+    id: c.id,
+    label: c.full_name_locale,
+    englishLabel: c.full_name_english,
+    abbreviation: c.two_letter_abbreviation,
+  }))
+  .sort((a, b) => a.label.localeCompare(b.label));
+
+const regionList: AddressGetter['regionList'] = (country: Country) => (country?.available_regions ? country.available_regions
+  .filter((c) => c.id && c.code && c.name)
+  .map((c) => ({
+    id: c.id,
+    label: c.name,
+    abbreviation: c.code,
+  } as {
+    id: number;
+    label: string;
+    abbreviation: string;
+  }))
+  .sort((a, b) => a.label.localeCompare(b.label)) : []);
+
+export default {
+  countriesList,
+  regionList,
+} as AddressGetter;

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -1,0 +1,209 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import {
+  CartGetters as CartGettersBase,
+  AgnosticPrice,
+  AgnosticTotals,
+  AgnosticAttribute,
+  AgnosticCoupon,
+  AgnosticDiscount,
+} from '@vue-storefront/core';
+import {
+  Discount,
+  Cart,
+  CartItem,
+  Product,
+  SelectedShippingMethod, ConfigurableCartItem, ProductInterface,
+} from '@vue-storefront/magento-api';
+
+import productGetters from './productGetters';
+import { AgnosticPaymentMethod } from '../types';
+
+export const getItems = (cart: Cart): CartItem[] => {
+  if (!cart || !cart.items) {
+    return [];
+  }
+
+  return cart.items;
+};
+
+export const getItemName = (product: CartItem): string => productGetters.getName(product.product as Product);
+
+export const getSlug = (product: CartItem): string => productGetters.getSlug(product.product as Product);
+
+export const getItemImage = (product: CartItem): string => productGetters.getProductThumbnailImage(product.product as Product);
+
+export const getItemPrice = (product: CartItem): AgnosticPrice => {
+  if (!product || !product.prices) {
+    return {
+      regular: 0,
+      special: 0,
+    };
+  }
+  if (product.prices) {
+    return {
+      regular: product.prices.row_total.value || 0,
+      special: product.prices.total_item_discount.value || 0,
+    };
+  }
+  const regularPrice = product.product?.price_range?.minimum_price?.regular_price?.value;
+  const specialPrice = product.product?.price_range?.minimum_price?.final_price?.value;
+
+  return {
+    regular: regularPrice || 0,
+    special: specialPrice || 0,
+    // @ts-ignore
+    credit: Math.round(specialPrice / 10),
+    // @TODO: Who set this installment value?
+    installment: Math.round((specialPrice * 1.1046) / 10),
+    discountPercentage: 100 - Math.round((specialPrice / regularPrice) * 100),
+    total: product.prices?.row_total?.value,
+  };
+};
+
+export const productHasSpecialPrice = (product: CartItem): boolean => getItemPrice(product).regular < getItemPrice(product).special;
+
+export const getItemQty = (product: CartItem): number => product.quantity;
+
+export const getItemAttributes = (
+  { product }: CartItem & { product: Product },
+  _filterByAttributeName?: Array<string>,
+): Record<string, AgnosticAttribute | string> => {
+  const attributes = {};
+
+  if (!product || !product.configurable_options) {
+    return attributes;
+  }
+
+  const configurableOptions = product.configurable_options;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const option of configurableOptions) {
+    attributes[option.attribute_code] = {
+      name: option.attribute_code,
+      label: option.label,
+      value: option.values.map((value) => {
+        const obj = {};
+        obj[value.value_index] = value.label;
+        return obj;
+      }),
+    } as AgnosticAttribute;
+  }
+  return attributes;
+};
+
+export const getItemSku = (product: CartItem): string => product?.product?.sku || '';
+
+const calculateDiscounts = (discounts: Discount[]): number => discounts.reduce((a, b) => Number.parseFloat(`${a}`) + Number.parseFloat(`${b.amount.value}`), 0);
+
+export const getTotals = (cart: Cart): AgnosticTotals => {
+  if (!cart || !cart.prices) return {} as AgnosticTotals;
+
+  const subtotal = cart.prices.subtotal_including_tax.value;
+  return {
+    total: cart.prices.grand_total.value,
+    subtotal: cart.prices.subtotal_including_tax.value,
+    special: (cart.prices.discounts) ? subtotal - calculateDiscounts(cart.prices.discounts) : subtotal,
+  } as AgnosticTotals;
+};
+
+export const getShippingPrice = (cart: Cart): number => {
+  if (!cart.shipping_addresses) {
+    return 0;
+  }
+
+  return cart.shipping_addresses
+    .reduce((
+      acc,
+      shippingAddress,
+    ) => {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      const { selected_shipping_method } = shippingAddress;
+
+      if (selected_shipping_method) {
+        // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
+        return acc + selected_shipping_method.amount.value;
+      }
+
+      return acc;
+    }, 0);
+};
+
+export const getTotalItems = (cart: Cart): number => {
+  if (!cart) {
+    return 0;
+  }
+  return cart.total_quantity;
+};
+
+export const getConfiguredVariant = (product: ConfigurableCartItem): ProductInterface | null => product?.configured_variant || null;
+
+// eslint-disable-next-line import/no-named-as-default-member
+export const getFormattedPrice = (price: number) => productGetters.getFormattedPrice(price);
+
+export const getCoupons = (cart: Cart): AgnosticCoupon[] => (Array.isArray(cart?.applied_coupons) ? cart.applied_coupons.map((c) => ({
+  id: c.code,
+  name: c.code,
+  value: 0,
+  code: c.code,
+} as AgnosticCoupon)) : []);
+
+export const getDiscounts = (cart: Cart): AgnosticDiscount[] => (Array.isArray(cart?.prices?.discounts) ? cart.prices.discounts.map((d) => ({
+  id: d.label,
+  name: d.label,
+  description: '',
+  value: d.amount.value,
+  code: d.label,
+} as AgnosticDiscount)) : []);
+
+export const getAppliedCoupon = (cart: Cart): AgnosticCoupon | null => (Array.isArray(cart?.applied_coupons) && cart?.applied_coupons.length > 0 ? {
+  id: cart.applied_coupons[0].code,
+  name: cart.applied_coupons[0].code,
+  value: 0,
+  code: cart.applied_coupons[0].code,
+} : null);
+
+export const getSelectedShippingMethod = (cart: Cart): SelectedShippingMethod | null => (cart?.shipping_addresses?.length > 0
+  ? cart?.shipping_addresses[0]?.selected_shipping_method
+  : null);
+
+export const getAvailablePaymentMethods = (cart: Cart): AgnosticPaymentMethod[] => cart?.available_payment_methods.map((p) => ({
+  label: p.title,
+  value: p.code,
+}));
+
+export const getStockStatus = (product: CartItem): string => product.product.stock_status;
+export interface CartGetters extends CartGettersBase<Cart, CartItem> {
+  getAppliedCoupon(cart: Cart): AgnosticCoupon | null;
+  getAvailablePaymentMethods(cart: Cart): AgnosticPaymentMethod[];
+  getSelectedShippingMethod(cart: Cart): SelectedShippingMethod | null;
+  productHasSpecialPrice(product: CartItem): boolean;
+  getStockStatus(product: CartItem): string;
+  getConfiguredVariant(product: ConfigurableCartItem): ProductInterface | null;
+}
+
+const cartGetters: CartGetters = {
+  getAppliedCoupon,
+  getAvailablePaymentMethods,
+  getCoupons,
+  getDiscounts,
+  getFormattedPrice,
+  getItemAttributes,
+  getItemImage,
+  getItemName,
+  getSlug,
+  getItemPrice,
+  getItemQty,
+  getItems,
+  getItemSku,
+  getSelectedShippingMethod,
+  getShippingPrice,
+  getTotalItems,
+  getTotals,
+  productHasSpecialPrice,
+  getStockStatus,
+  getConfiguredVariant,
+};
+
+export default cartGetters;

--- a/packages/composables/src/getters/categoryGetters.ts
+++ b/packages/composables/src/getters/categoryGetters.ts
@@ -1,0 +1,54 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { CategoryGetters, AgnosticCategoryTree, AgnosticBreadcrumb } from '@vue-storefront/core';
+import { Category } from '@vue-storefront/magento-api';
+import { buildCategoryTree } from '../helpers/buildCategoryTree';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getTree = (category: Category): AgnosticCategoryTree | null => {
+  if (!category) {
+    return null;
+  }
+  return buildCategoryTree(category, '');
+};
+
+export const getCategoryTree = (
+  category: Category,
+  currentCategory: string = '',
+  withProducts = false,
+): AgnosticCategoryTree | null => (
+  category
+    ? buildCategoryTree(category, currentCategory, withProducts)
+    : null
+);
+
+export const getCategoryBreadcrumbs = (category: any): AgnosticBreadcrumb[] => {
+  let breadcrumbs = [];
+
+  if (!category) {
+    return [];
+  }
+
+  if (Array.isArray(category?.breadcrumbs)) {
+    breadcrumbs = category.breadcrumbs.map((breadcrumb) => ({
+      text: breadcrumb.category_name,
+      link: `/c/${breadcrumb.category_url_path}${category.url_suffix || ''}`,
+    } as AgnosticBreadcrumb));
+  }
+
+  breadcrumbs.push({
+    text: category.name,
+    link: `/c/${category.url_path}${category.url_suffix || ''}`,
+  } as AgnosticBreadcrumb);
+
+  return breadcrumbs;
+};
+
+const categoryGetters: CategoryGetters<Category> = {
+  getTree,
+  getBreadcrumbs: getCategoryBreadcrumbs,
+  getCategoryTree,
+};
+
+export default categoryGetters;

--- a/packages/composables/src/getters/checkoutGetters.ts
+++ b/packages/composables/src/getters/checkoutGetters.ts
@@ -1,0 +1,30 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { ShippingMethod } from '@vue-storefront/magento-api';
+import productGetters from './productGetters';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getShippingMethodId = (shippingMethod: ShippingMethod): string => '';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getShippingMethodName = (shippingMethod: ShippingMethod): string => '';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getShippingMethodDescription = (shippingMethod: ShippingMethod): string => '';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getShippingMethodPrice = (shippingMethod: ShippingMethod): number => 0;
+
+// eslint-disable-next-line import/no-named-as-default-member
+export const getFormattedPrice = (price: number) => productGetters.getFormattedPrice(price);
+
+const checkoutGetters = {
+  getShippingMethodId,
+  getShippingMethodName,
+  getShippingMethodDescription,
+  getFormattedPrice,
+  getShippingMethodPrice,
+};
+
+export default checkoutGetters;

--- a/packages/composables/src/getters/facetGetters.ts
+++ b/packages/composables/src/getters/facetGetters.ts
@@ -1,0 +1,99 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import {
+  FacetsGetters,
+  AgnosticCategoryTree,
+  AgnosticGroupedFacet,
+  AgnosticPagination,
+  AgnosticSort,
+  AgnosticBreadcrumb,
+  AgnosticFacet,
+} from '@vue-storefront/core';
+
+import {
+  buildFacets,
+  reduceForGroupedFacets,
+  reduceForFacets,
+} from '../composables/useFacet/_utils';
+
+import {
+  SearchData,
+} from '../types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getAll = (searchData: SearchData, criteria?: string[]): AgnosticFacet[] => buildFacets(searchData, reduceForFacets, criteria);
+
+const getGrouped = (searchData, criteria?: string[]): AgnosticGroupedFacet[] => buildFacets(searchData, reduceForGroupedFacets, criteria)
+  ?.filter((facet) => facet.options && facet.options.length > 0);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getSortOptions = (searchData): AgnosticSort => {
+  if (!searchData || !searchData.data || !searchData.data.availableSortingOptions) {
+    return {
+      options: [],
+      selected: '',
+    } as AgnosticSort;
+  }
+
+  return {
+    options: searchData.data.availableSortingOptions,
+    selected: searchData.input.sort,
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getCategoryTree = (searchData): AgnosticCategoryTree => {
+  const buildTree = (category: any): AgnosticCategoryTree => ({
+    label: category.name,
+    slug: category.url_path,
+    items: (category.children) ? category.children.map((element) => buildTree(element)) : [],
+    isCurrent: (category.name === searchData.data.category.name),
+  });
+
+  if (!searchData.data || !searchData.data.category.children) {
+    return {} as AgnosticCategoryTree;
+  }
+
+  return buildTree(searchData.data.category);
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getProducts = (searchData): any => {
+  if (!searchData || !searchData.data || !searchData.data.items) {
+    return [];
+  }
+  return searchData.data.items;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getPagination = (searchData): AgnosticPagination => {
+  const totalPages = (searchData?.data) ? (
+    Number.isNaN(Math.ceil(searchData.data.total / searchData.input.itemsPerPage))
+      ? 1
+      : Math.ceil(searchData.data.total / searchData.input.itemsPerPage)
+  ) : 1;
+
+  return {
+    currentPage: (searchData?.input?.page > totalPages ? 1 : searchData?.input?.page) || 1,
+    totalPages,
+    totalItems: (searchData?.data?.total) ? searchData.data.total : 0,
+    itemsPerPage: searchData?.input?.itemsPerPage || 10,
+    pageOptions: [10, 50, 100],
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const getBreadcrumbs = (searchData): AgnosticBreadcrumb[] => [];
+
+const facetGetters: FacetsGetters<any, any> = {
+  getSortOptions,
+  getGrouped,
+  getAll,
+  getProducts,
+  getCategoryTree,
+  getBreadcrumbs,
+  getPagination,
+};
+
+export default facetGetters;

--- a/packages/composables/src/getters/forgotPasswordGetters.ts
+++ b/packages/composables/src/getters/forgotPasswordGetters.ts
@@ -1,0 +1,18 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { ForgotPasswordGetters } from '@vue-storefront/core';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getResetPasswordToken(result: any): string {
+  return '';
+}
+
+const isPasswordChanged = (result: any): boolean => result?.resetPassword;
+
+export const forgotPasswordGetters: ForgotPasswordGetters<any> = {
+  getResetPasswordToken,
+  isPasswordChanged,
+};
+
+export default forgotPasswordGetters;

--- a/packages/composables/src/getters/index.ts
+++ b/packages/composables/src/getters/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+export { default as addressGetter } from './addressGetter';
+export { default as cartGetters } from './cartGetters';
+export { default as categoryGetters } from './categoryGetters';
+export { default as checkoutGetters } from './checkoutGetters';
+export { default as facetGetters } from './facetGetters';
+export { default as forgotPasswordGetters } from './forgotPasswordGetters';
+export { default as orderGetters } from './orderGetters';
+export { default as productGetters } from './productGetters';
+export { default as reviewGetters } from './reviewGetters';
+export { default as storeGetters } from './storeGetters';
+export { default as userAddressesGetters } from './userAddressesGetters';
+export { default as userBillingGetters } from './userBillingGetters';
+export { default as userGetters } from './userGetters';
+export { default as userShippingGetters } from './userShippingGetters';
+export { default as wishlistGetters } from './wishlistGetters';
+export { default as storeConfigGetters } from './storeConfigGetters';

--- a/packages/composables/src/getters/orderGetters.ts
+++ b/packages/composables/src/getters/orderGetters.ts
@@ -1,0 +1,48 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { AgnosticPagination } from '@vue-storefront/core';
+
+export const getDate = (order: any): string => new Date(order?.created_at).toLocaleDateString() || '';
+
+export const getId = (order: any): string => String(Number.parseInt(order?.order_number, 10) || Math.floor(Math.random() * 100));
+
+export const getStatus = (order: any): string => order?.status || 'Failed';
+
+export const getPrice = (order: any): number | null => order?.grand_total || 0;
+
+export const getItems = (order: any): any[] => order?.items || [];
+
+export const getItemSku = (item: any): string => item?.product_sku || 0;
+
+export const getItemName = (item: any): string => item?.product_name || 0;
+
+export const getItemQty = (item: any): number => item?.quantity_ordered || 0;
+
+export const getItemPrice = (item: any): number => item?.product_sale_price?.value || 0;
+
+export const getFormattedPrice = (price: number) => String(price);
+
+const getPagination = (orders: any): AgnosticPagination => ({
+  currentPage: orders?.page_info?.current_page || 1,
+  totalPages: orders?.page_info?.total_pages || 1,
+  totalItems: orders?.total_count || 0,
+  itemsPerPage: orders?.page_info?.page_size || 10,
+  pageOptions: [10, 50, 100],
+});
+
+const orderGetters = {
+  getDate,
+  getId,
+  getStatus,
+  getPrice,
+  getItems,
+  getItemSku,
+  getItemName,
+  getItemQty,
+  getItemPrice,
+  getFormattedPrice,
+  getPagination,
+};
+
+export default orderGetters;

--- a/packages/composables/src/getters/productGetters.ts
+++ b/packages/composables/src/getters/productGetters.ts
@@ -1,0 +1,296 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import {
+  AgnosticAttribute,
+  AgnosticBreadcrumb,
+  AgnosticMediaGalleryItem,
+  AgnosticPrice,
+  ProductGetters as ProductGettersBase,
+} from '@vue-storefront/core';
+import {
+  BundleProduct,
+  Category, GroupedProduct,
+  Product,
+} from '@vue-storefront/magento-api';
+
+import categoryGetters from './categoryGetters';
+import { htmlDecode } from '../helpers/htmlDecoder';
+import reviewGetters from './reviewGetters';
+
+type ProductVariantFilters = any;
+
+export const getName = (product: Product): string => {
+  if (!product) {
+    return '';
+  }
+
+  return htmlDecode(product.name);
+};
+
+export const getSlug = (product: Product, category?: Category): string => {
+  const rewrites = product?.url_rewrites;
+  let url = product?.sku ? `/p/${product.sku}` : '';
+  if (!rewrites || rewrites.length === 0) {
+    return url;
+  }
+
+  url = `/${rewrites[0].url}`;
+  // eslint-disable-next-line no-restricted-syntax
+  for (const rewrite of rewrites) {
+    if (category && category.uid) {
+      url = `/${rewrite.url}`;
+      break;
+    }
+  }
+
+  return url;
+};
+
+export const getPrice = (product: Product): AgnosticPrice => {
+  let regular = 0;
+  let special = null;
+
+  if (product?.price_range) {
+    regular = product.price_range.minimum_price.regular_price.value;
+    const final = product.price_range.minimum_price.final_price.value;
+
+    if (final < regular) {
+      special = final;
+    }
+  }
+
+  return {
+    regular,
+    special,
+  };
+};
+
+export const getGallery = (product: Product): AgnosticMediaGalleryItem[] => {
+  const images = [];
+
+  if (!product?.media_gallery && !product?.configurable_product_options_selection?.media_gallery) {
+    return images;
+  }
+
+  const selectedGallery = product.configurable_product_options_selection?.media_gallery
+    ? product.configurable_product_options_selection.media_gallery
+    : product.media_gallery;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const galleryItem of selectedGallery) {
+    images.push({
+      small: galleryItem.url,
+      normal: galleryItem.url,
+      big: galleryItem.url,
+    });
+  }
+
+  return images;
+};
+
+export const getCoverImage = (product: Product): string => {
+  if (!product || !product.image) {
+    return null;
+  }
+
+  return product.image.url;
+};
+
+export const getProductThumbnailImage = (product: Product): string => {
+  if (!product || !product.thumbnail) {
+    return null;
+  }
+
+  return product.thumbnail.url;
+};
+
+export const getFiltered = (products: Product[], filters: ProductVariantFilters | any = {}): Product[] => {
+  if (!products) {
+    return [];
+  }
+
+  return products;
+};
+
+export const getAttributes = (
+  products: Product,
+  _filterByAttributeName?: string[],
+): Record<string, AgnosticAttribute | string> => {
+  if (!products || !products?.configurable_options) {
+    return {};
+  }
+
+  const attributes = {};
+  const configurableOptions = products.configurable_options;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const option of configurableOptions) {
+    attributes[option.attribute_code] = {
+      name: option.attribute_code,
+      label: option.label,
+      value: option.values.map((value) => {
+        const obj = {};
+        obj[value.value_index] = value.label;
+        return obj;
+      }),
+    } as AgnosticAttribute;
+  }
+  return attributes;
+};
+
+export const getDescription = (product: Product): string => {
+  if (!product || !product?.description) {
+    return '';
+  }
+
+  return product.description.html;
+};
+
+export const getShortDescription = (product: Product): string => {
+  if (!product || !product.short_description) {
+    return '';
+  }
+  return product.short_description.html;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getCategoryIds = (product: Product): string[] => {
+  const categoryIds = [];
+
+  if (!product?.categories) {
+    return categoryIds;
+  }
+
+  return product.categories.map((category) => category.uid);
+};
+
+export const getCategory = (product: any, currentUrlPath: string): Category | null => {
+  if (!product?.categories || product?.categories.length === 0) {
+    return null;
+  }
+
+  const categories = currentUrlPath.split('/');
+  categories.pop();
+
+  if (categories.length === 0) {
+    return null;
+  }
+
+  const categoryPath = categories.join('/');
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const category of product.categories) {
+    if (`/${category.url_path}` === categoryPath) {
+      return category;
+    }
+  }
+
+  return null;
+};
+
+export const getId = (product: Product): string => product.uid;
+
+export const getProductSku = (product: Product): string => product.sku;
+
+// @ts-ignore
+// eslint-disable-next-line no-underscore-dangle
+export const getTypeId = (product: Product): string => product.__typename;
+
+export const getFormattedPrice = (price: number) => {
+  if (price === null) {
+    return null;
+  }
+
+  // TODO get correct data from api
+  const locale = 'en';
+  const country = 'en';
+  const currency = 'USD';
+
+  return new Intl.NumberFormat(`${locale}-${country}`, {
+    style: 'currency',
+    currency,
+  }).format(price);
+};
+
+export const getBreadcrumbs = (product: any, category?: Category): AgnosticBreadcrumb[] => {
+  let breadcrumbs = [];
+
+  if (!product) {
+    return breadcrumbs;
+  }
+
+  if (category) {
+    breadcrumbs = categoryGetters.getBreadcrumbs(category) as AgnosticBreadcrumb[];
+  }
+
+  breadcrumbs.push({
+    text: getName(product),
+    route: {
+      path: getSlug(product),
+    },
+  });
+
+  return breadcrumbs;
+};
+
+export const { getTotalReviews } = reviewGetters;
+
+export const { getAverageRating } = reviewGetters;
+
+export const getProductRelatedProduct = (product: any): Product[] => product?.related_products || [];
+
+export const getProductUpsellProduct = (product: any): Product[] => product?.upsell_products || [];
+
+export const getSwatchData = (swatchData: Product['configurable_options'][0]['values'][0]['swatch_data']): string | undefined => swatchData?.value;
+
+const sortProduct = (a, b) => a.position - b.position;
+
+// eslint-disable-next-line no-underscore-dangle
+export const getGroupedProducts = (product: GroupedProduct & { __typename: string }): GroupedProduct['items'] | undefined => product.__typename === 'GroupedProduct' && product?.items?.sort(sortProduct);
+
+// eslint-disable-next-line no-underscore-dangle
+export const getBundleProducts = (product: BundleProduct & { __typename: string }): BundleProduct['items'] | undefined => product.__typename === 'BundleProduct' && product?.items?.sort(sortProduct);
+
+export interface ProductGetters extends ProductGettersBase<Product, ProductVariantFilters>{
+  getCategory(product: Product, currentUrlPath: string): Category | null;
+  getProductRelatedProduct(product: Product): Product[];
+  getProductSku(product: Product): string;
+  getProductThumbnailImage(product: Product): string;
+  getProductUpsellProduct(product: Product): Product[];
+  getShortDescription(product: Product): string;
+  getSlug(product: Product, category?: Category): string;
+  getTypeId(product: Product): string;
+  getSwatchData(swatchData: Product['configurable_options'][0]['values'][0]['swatch_data']): string | undefined;
+  getGroupedProducts(product: GroupedProduct): GroupedProduct['items'] | undefined;
+  getBundleProducts(product: BundleProduct): BundleProduct['items'] | undefined;
+}
+
+const productGetters: ProductGetters = {
+  getAttributes,
+  getAverageRating,
+  getBreadcrumbs,
+  getCategory,
+  getCategoryIds,
+  getCoverImage,
+  getDescription,
+  getFiltered,
+  getFormattedPrice,
+  getGallery,
+  getId,
+  getName,
+  getPrice,
+  getProductRelatedProduct,
+  getProductSku,
+  getProductThumbnailImage,
+  getProductUpsellProduct,
+  getShortDescription,
+  getSlug,
+  getTotalReviews,
+  getTypeId,
+  getSwatchData,
+  getGroupedProducts,
+  getBundleProducts,
+};
+
+export default productGetters;

--- a/packages/composables/src/getters/reviewGetters.ts
+++ b/packages/composables/src/getters/reviewGetters.ts
@@ -1,0 +1,66 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { ReviewGetters, AgnosticRateCount } from '@vue-storefront/core';
+import {
+  ProductReview,
+  ProductReviewRatingMetadata,
+  ProductReviews,
+  ReviewMetadata,
+} from '@vue-storefront/magento-api';
+import { AgnosticReviewMetadata } from '../types';
+
+export const getItems = (review): ProductReview[] => review?.reviews?.items || [];
+
+export const getReviewId = (item: ProductReview): string => `${item.nickname}_${item.created_at}_${item.average_rating}`;
+
+export const getReviewAuthor = (item: ProductReview): string => item.nickname;
+
+export const getReviewMessage = (item: ProductReview): string => item.text;
+
+export const getReviewRating = (item: ProductReview): number => Number.parseInt(
+  item.ratings_breakdown.find((r) => r.name === 'Rating')?.value,
+  10,
+) || 0;
+
+export const getReviewDate = (item: ProductReview): string => item.created_at;
+
+export const getTotalReviews = (review: ProductReviews): number => review?.review_count || 0;
+
+export const getAverageRating = (review): number => (review?.reviews?.items?.reduce((acc, curr) => Number.parseInt(`${acc}`, 10) + getReviewRating(curr), 0)) / (review?.review_count || 1) || 0;
+
+export const getRatesCount = (_review: ProductReviews): AgnosticRateCount[] => [];
+
+export const getReviewsPage = (review: ProductReviews): number => review?.reviews.page_info?.page_size || 0;
+
+export const getReviewMetadata = (reviewData: ProductReviewRatingMetadata[]): AgnosticReviewMetadata[] => reviewData?.map((m) => ({
+  ...m,
+  values: m.values.map((v) => ({
+    label: (Number.parseInt(v.value, 10) || v.value),
+    id: v.value_id,
+  })),
+}));
+
+export const getProductName = (review: ProductReview): string => review?.product?.name || '';
+
+interface MagentoReviewGetters extends ReviewGetters<ProductReviews, ProductReview> {
+  getReviewMetadata(reviewData: ReviewMetadata[]): AgnosticReviewMetadata[];
+  getProductName(reviewData: ProductReview): string;
+}
+
+const reviewGetters: MagentoReviewGetters = {
+  getAverageRating,
+  getItems,
+  getRatesCount,
+  getReviewAuthor,
+  getReviewDate,
+  getReviewId,
+  getReviewMessage,
+  getReviewMetadata,
+  getReviewRating,
+  getReviewsPage,
+  getTotalReviews,
+  getProductName,
+};
+
+export default reviewGetters;

--- a/packages/composables/src/getters/storeConfigGetters.ts
+++ b/packages/composables/src/getters/storeConfigGetters.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated since version 1.0.0
+ */
 import { StoreConfig } from '@vue-storefront/magento-api';
 
 const getCode = (config: StoreConfig) => config.store_code;

--- a/packages/composables/src/getters/storeGetters.ts
+++ b/packages/composables/src/getters/storeGetters.ts
@@ -1,0 +1,20 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { AvailableStores, StoreConfig } from '@vue-storefront/magento-api';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getItems(stores: AvailableStores, criteria: any = {}): AvailableStores {
+  return stores;
+}
+
+function getSelected(config: StoreConfig, store: StoreConfig): boolean {
+  return config.store_code === store.store_code;
+}
+
+const storeGetters = {
+  getItems,
+  getSelected,
+};
+
+export default storeGetters;

--- a/packages/composables/src/getters/userAddressesGetters.ts
+++ b/packages/composables/src/getters/userAddressesGetters.ts
@@ -1,0 +1,52 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { UserAddressesGetters as BaseGetters } from '../types/getters';
+import { transformUserGetter } from '../helpers/userAddressManipulator';
+
+interface UserAddressesGetters extends BaseGetters<any, any>{
+  getNeighborhood: (address: any) => string
+  getAddressExtra: (address: any) => string
+}
+
+const userAddressesGetters: UserAddressesGetters = {
+  getAddresses: (addresses, criteria?: Record<string, any>) => {
+    if (!addresses || addresses.length === 0 || !Array.isArray(addresses)) return [];
+
+    const addressesData = addresses?.map((a) => transformUserGetter(a))
+      ?.sort((a, b) => ((a.default_shipping === b.default_shipping) ? 0 : (a.default_shipping ? -1 : 1)))
+      ?.sort((a, b) => ((a.default_billing === b.default_billing) ? 0 : (a.default_billing ? -1 : 1)));
+
+    if (!criteria || Object.keys(criteria).length === 0) {
+      return addressesData;
+    }
+
+    const entries = Object.entries(criteria);
+    return addressesData.filter((address) => entries.every(([key, value]) => address[key] === value));
+  },
+  getDefault: (addresses) => addresses.find(({ isDefault }) => isDefault),
+  getTotal: (addresses) => addresses.length,
+
+  getPostCode: (address) => address?.postcode || '',
+  getStreetName: (address) => (Array.isArray(address?.street) ? address?.street[0] : address?.street),
+  getStreetNumber: (address) => address?.streetNumber || '',
+  getCity: (address) => address?.city || '',
+  getFirstName: (address) => address?.firstname || '',
+  getLastName: (address) => address?.lastname || '',
+  getCountry: (address) => address?.country_code || '',
+  getPhone: (address) => address?.phone || '',
+  getEmail: (address) => address?.email || '',
+  getProvince: (address) => (address?.region?.region_code || address?.region?.region) || '',
+  getCompanyName: (address) => address?.company || '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getTaxNumber: (address) => address?.vat_id || '',
+  getId: (address) => address?.id || '',
+  getApartmentNumber: (address) => (Array.isArray(address?.street) ? address?.street[1] : address?.apartment),
+  getNeighborhood: (address) => (Array.isArray(address?.street) ? address?.street[2] : address?.neighborhood),
+  getAddressExtra: (address) => (Array.isArray(address?.street) ? address?.street[3] : address?.extra),
+  isDefault: (address) => (address?.default_shipping || address?.default_billing) || false,
+  isDefaultShipping: (address) => address?.default_shipping || false,
+  isDefaultBilling: (address) => address?.default_billing || false,
+};
+
+export default userAddressesGetters;

--- a/packages/composables/src/getters/userBillingGetters.ts
+++ b/packages/composables/src/getters/userBillingGetters.ts
@@ -1,0 +1,43 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { UserBillingGetters as BaseGetters } from '@vue-storefront/core';
+
+interface UserBillingGetters extends BaseGetters<any, any>{
+  getNeighborhood: (address: any) => string
+  getAddressExtra: (address: any) => string
+}
+
+const userBillingGetters: UserBillingGetters = {
+  getAddresses: (billing, criteria?: Record<string, any>) => {
+    if (!criteria || Object.keys(criteria).length === 0) {
+      return billing.addresses;
+    }
+
+    const entries = Object.entries(criteria);
+    return billing.addresses.filter((address) => entries.every(([key, value]) => address[key] === value));
+  },
+  getDefault: (billing) => billing.addresses.find(({ isDefault }) => isDefault),
+  getTotal: (billing) => billing.addresses.length,
+
+  getPostCode: (address) => address?.postcode || '',
+  getStreetName: (address) => (Array.isArray(address?.street) ? address?.street[0] : ''),
+  getStreetNumber: (address) => address?.streetNumber || '',
+  getCity: (address) => address?.city || '',
+  getFirstName: (address) => address?.firstname || '',
+  getLastName: (address) => address?.lastname || '',
+  getCountry: (address) => address?.country_code || '',
+  getPhone: (address) => address?.phone || '',
+  getEmail: (address) => address?.email || '',
+  getProvince: (address) => (address?.region?.region_code || address?.region?.region) || '',
+  getCompanyName: (address) => address?.company || '',
+  getNeighborhood: (address) => (Array.isArray(address?.street) ? address?.street[2] : address?.neighborhood),
+  getAddressExtra: (address) => (Array.isArray(address?.street) ? address?.street[3] : address?.extra),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getTaxNumber: (address) => address.vat_id || '',
+  getId: (address) => address?.id || '',
+  getApartmentNumber: (address) => (Array.isArray(address?.street) ? address?.street[1] : ''),
+  isDefault: (address) => address?.default_billing || false,
+};
+
+export default userBillingGetters;

--- a/packages/composables/src/getters/userGetters.ts
+++ b/packages/composables/src/getters/userGetters.ts
@@ -1,0 +1,22 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { UserGetters as BaseUserGetters } from '@vue-storefront/core';
+import { Customer } from '@vue-storefront/magento-api';
+
+export const getFirstName = (user: Customer): string => (user ? user.firstname : '');
+
+export const getLastName = (user: Customer): string => (user ? user.lastname : '');
+
+export const getEmailAddress = (user: Customer): string => (user ? user.email : '');
+
+export const getFullName = (user: Customer): string => (user ? `${user.firstname} ${user.lastname}` : '');
+
+const userGetters: BaseUserGetters<Customer> = {
+  getFirstName,
+  getLastName,
+  getEmailAddress,
+  getFullName,
+};
+
+export default userGetters;

--- a/packages/composables/src/getters/userShippingGetters.ts
+++ b/packages/composables/src/getters/userShippingGetters.ts
@@ -1,0 +1,39 @@
+/**
+ * @deprecated since version 1.0.0
+ */
+import { Logger, UserShippingGetters } from '@vue-storefront/core';
+
+const userShippingGetters: UserShippingGetters<any, any> = {
+  getAddresses: (shipping, criteria?: Record<string, any>) => {
+    Logger.debug(shipping);
+    if (!shipping || !shipping.addresses) return [] as Record<string, any>;
+
+    if (!criteria || Object.keys(criteria).length === 0) {
+      return shipping.addresses;
+    }
+
+    const entries = Object.entries(criteria);
+    return shipping.addresses.filter((address) => entries.every(([key, value]) => address[key] === value));
+  },
+  getDefault: (shipping) => shipping.addresses.find(({ isDefault }) => isDefault),
+  getTotal: (shipping) => shipping.addresses.length,
+
+  getPostCode: (address) => address?.postcode || '',
+  getStreetName: (address) => (Array.isArray(address?.street) ? address?.street[0] : ''),
+  getStreetNumber: (address) => address?.streetNumber || '',
+  getCity: (address) => address?.city || '',
+  getFirstName: (address) => address?.firstname || '',
+  getLastName: (address) => address?.lastname || '',
+  getCountry: (address) => address?.country_code || '',
+  getPhone: (address) => address?.phone || '',
+  getEmail: (address) => address?.email || '',
+  getProvince: (address) => (address?.region?.region_code || address?.region?.region) || '',
+  getCompanyName: (address) => address?.company || '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  getTaxNumber: (address) => '',
+  getId: (address) => address?.id || '',
+  getApartmentNumber: (address) => (Array.isArray(address?.street) ? address?.street[1] : ''),
+  isDefault: (address) => address?.default_shipping || false,
+};
+
+export default userShippingGetters;

--- a/packages/composables/src/getters/wishlistGetters.ts
+++ b/packages/composables/src/getters/wishlistGetters.ts
@@ -1,4 +1,6 @@
-/* istanbul ignore file */
+/**
+ * @deprecated since version 1.0.0
+ */
 import {
   WishlistGetters as BaseWishlistGetters,
   AgnosticPrice,

--- a/packages/composables/src/index.ts
+++ b/packages/composables/src/index.ts
@@ -3,6 +3,7 @@ import { track } from '@vue-storefront/core';
 
 track('VSFMagento');
 
+export * from './getters';
 export * from './getVueContext';
 
 export { default as useAddresses } from './composables/useAddresses';
@@ -43,7 +44,7 @@ export * from './types/getters';
 export * from './helpers/userAddressManipulator';
 export * from './helpers/htmlDecoder';
 export {
-    Countries, Discount,
-    SelectedShippingMethod, ConfigurableCartItem, ProductInterface, ProductReviewRatingMetadata,
-    ProductReviews, WishlistQuery,
+  Countries, Discount,
+  SelectedShippingMethod, ConfigurableCartItem, ProductInterface, ProductReviewRatingMetadata,
+  ProductReviews, WishlistQuery,
 } from '@vue-storefront/magento-api';


### PR DESCRIPTION
We must keep getters in legacy code as long as legacy code is a part of the application

## Description
- copy getters back to the legacy composables for a backward compatibility package and mark all as deprecated

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
