### PR TITLE
refactor(composables):  use payment provider

### DIFF
--- a/packages/composables/src/composables/usePaymentProvider/index.ts
+++ b/packages/composables/src/composables/usePaymentProvider/index.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated since version 1.0.0
+ */
 import {
   Context,
   Logger,

--- a/packages/composables/src/factories/usePaymentProviderFactory.ts
+++ b/packages/composables/src/factories/usePaymentProviderFactory.ts
@@ -1,3 +1,6 @@
+/**
+ * @deprecated since version 1.0.0
+ */
 import { Ref, computed } from '@vue/composition-api';
 import {
   ComposableFunctionArgs,

--- a/packages/theme/components/Checkout/VsfPaymentProvider.vue
+++ b/packages/theme/components/Checkout/VsfPaymentProvider.vue
@@ -26,7 +26,7 @@ import {
   computed,
   defineComponent,
 } from '@nuxtjs/composition-api';
-import { usePaymentProvider } from '@vue-storefront/magento';
+import { usePaymentProvider } from '~/composables';
 
 export default defineComponent({
   name: 'VsfPaymentProvider',
@@ -38,11 +38,12 @@ export default defineComponent({
   emits: ['status'],
 
   setup(props, { emit }) {
-    const { load, state, save } = usePaymentProvider();
+    const state = ref(null);
+    const { load, save } = usePaymentProvider();
     const selectedMethod = ref(null);
 
     onMounted(async () => {
-      await load();
+      state.value = await load();
     });
 
     const paymentMethods = computed(() => (Array.isArray(state.value) ? state.value.map((p) => ({
@@ -52,7 +53,7 @@ export default defineComponent({
 
     const definePaymentMethods = async (paymentMethod) => {
       try {
-        await save({
+        state.value = await save({
           paymentMethod: {
             code: paymentMethod,
           },

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -21,3 +21,4 @@ export { default as useShipping } from './useShipping';
 export { default as useShippingProvider } from './useShippingProvider';
 export { default as useBilling } from './useBilling';
 export { default as useRelatedProducts } from './useRelatedProducts';
+export { default as usePaymentProvider } from './usePaymentProvider';

--- a/packages/theme/composables/usePaymentProvider/commands/getAvailablePaymentMethodsCommand.ts
+++ b/packages/theme/composables/usePaymentProvider/commands/getAvailablePaymentMethodsCommand.ts
@@ -1,0 +1,15 @@
+import { AvailablePaymentMethod } from '~/modules/GraphQL/types';
+
+export const getAvailablePaymentMethodsCommand = {
+  execute: async (context, cartId: string): Promise<AvailablePaymentMethod> => {
+    const { data } = await context
+      .$vsf
+      .$magento
+      .api
+      .getAvailablePaymentMethods({ cartId });
+
+    return data
+      .cart
+      .available_payment_methods;
+  },
+};

--- a/packages/theme/composables/usePaymentProvider/commands/setPaymentMethodOnCartCommand.ts
+++ b/packages/theme/composables/usePaymentProvider/commands/setPaymentMethodOnCartCommand.ts
@@ -1,0 +1,17 @@
+import { AvailablePaymentMethod } from '~/modules/GraphQL/types';
+import { SetPaymentMethodOnCartInputs } from '../usePaymentProvider';
+
+export const setPaymentMethodOnCartCommand = {
+  execute: async (context, paymentMethodParams: SetPaymentMethodOnCartInputs): Promise<AvailablePaymentMethod> => {
+    const { data } = await context
+      .$vsf
+      .$magento
+      .api
+      .setPaymentMethodOnCart(paymentMethodParams);
+
+    return data
+      .setPaymentMethodOnCart
+      .cart
+      .available_payment_methods;
+  },
+};

--- a/packages/theme/composables/usePaymentProvider/index.ts
+++ b/packages/theme/composables/usePaymentProvider/index.ts
@@ -1,0 +1,73 @@
+import { Logger } from '@vue-storefront/core';
+import { ref, useContext } from '@nuxtjs/composition-api';
+import { PaymentMethodInput } from '~/modules/GraphQL/types';
+import { ComposableFunctionArgs } from '~/composables/types';
+import { setPaymentMethodOnCartCommand } from '~/composables/usePaymentProvider/commands/setPaymentMethodOnCartCommand';
+import { useCart } from '~/composables';
+import { getAvailablePaymentMethodsCommand } from '~/composables/usePaymentProvider/commands/getAvailablePaymentMethodsCommand';
+import { SetPaymentMethodOnCartInputs } from './usePaymentProvider';
+
+export const usePaymentProvider = () => {
+  const context = useContext();
+  const { cart } = useCart();
+  const loading = ref(false);
+  // eslint-disable-next-line @typescript-eslint/naming-convention,no-underscore-dangle
+  const error = ref({
+    load: null,
+    save: null,
+  });
+
+  const save = async (params: ComposableFunctionArgs<{ paymentMethod: PaymentMethodInput }>) => {
+    Logger.debug('usePaymentProvider.save');
+    let result = null;
+
+    try {
+      loading.value = true;
+      const paymentMethodParams: SetPaymentMethodOnCartInputs = {
+        cart_id: cart.value.id,
+        payment_method: {
+          ...params.paymentMethod,
+        },
+      };
+
+      result = await setPaymentMethodOnCartCommand.execute(context, paymentMethodParams);
+      error.value.save = null;
+    } catch (err) {
+      error.value.save = err;
+      Logger.error('usePaymentProvider/save', err);
+    } finally {
+      loading.value = false;
+    }
+
+    Logger.debug('[Result]:', { result });
+    return result;
+  };
+
+  const load = async () => {
+    Logger.debug('usePaymentProvider.load');
+    let result = null;
+
+    try {
+      loading.value = true;
+      result = await getAvailablePaymentMethodsCommand.execute(context, cart.value.id);
+      error.value.load = null;
+    } catch (err) {
+      error.value.load = err;
+      Logger.error('usePaymentProvider/load', err);
+    } finally {
+      loading.value = false;
+    }
+
+    Logger.debug('[Result]:', { result });
+    return result;
+  };
+
+  return {
+    loading,
+    error,
+    load,
+    save,
+  };
+};
+
+export default usePaymentProvider;

--- a/packages/theme/composables/usePaymentProvider/usePaymentProvider.d.ts
+++ b/packages/theme/composables/usePaymentProvider/usePaymentProvider.d.ts
@@ -1,0 +1,10 @@
+import { PaymentMethodInput, Scalars } from '~/modules/GraphQL/types';
+
+export interface SetPaymentMethodOnCartInput {
+  cart_id: Scalars['String'];
+  payment_method: PaymentMethodInput;
+}
+
+export interface SetPaymentMethodOnCartInputs extends SetPaymentMethodOnCartInput {
+  [k: string]: any;
+}


### PR DESCRIPTION
## Description
Refactor use payment provider, move it to the Theme package, mark composable as deprecated

## Related Issue
-

## Motivation and Context
-

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
