### PR TITLE
fix(checkout): fix issue with blocked payment method step

### DIFF
--- a/packages/theme/pages/Checkout/Billing.vue
+++ b/packages/theme/pages/Checkout/Billing.vue
@@ -334,7 +334,7 @@ export default defineComponent({
     const userBilling = ref({});
 
     const {
-      load, save, loading,
+      save, loading,
     } = useBilling();
     const {
       load: loadUserBilling,
@@ -347,6 +347,7 @@ export default defineComponent({
       load: loadCountries,
       search: searchCountry,
     } = useCountrySearch();
+
     const countries = ref([]);
     const country = ref(null);
     const { isAuthenticated } = useUser();
@@ -361,7 +362,7 @@ export default defineComponent({
     const isBillingDetailsStepCompleted = ref(false);
     const addresses = computed(() => userBillingGetters.getAddresses(userBilling.value) ?? []);
 
-    const canMoveForward = computed(() => !loading.value && currentAddressId.value && billingDetails.value && Object.keys(
+    const canMoveForward = computed(() => !loading.value && billingDetails.value && Object.keys(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       billingDetails.value,
     ).length > 0);
@@ -474,9 +475,7 @@ export default defineComponent({
         await router.push(app.localePath('/checkout/user-account'));
       }
 
-      const [loadedBilling, loadedCountries] = await Promise.all([load(), loadCountries()]);
-      billingAddress.value = loadedBilling;
-      countries.value = loadedCountries;
+      countries.value = await loadCountries();
       if (billingDetails.value?.country_code) {
         country.value = await searchCountry({ id: billingDetails.value.country_code });
       }
@@ -517,7 +516,6 @@ export default defineComponent({
       isAuthenticated,
       isFormSubmitted,
       isBillingDetailsStepCompleted,
-      load,
       loading,
       NOT_SELECTED_ADDRESS,
       regionInformation,


### PR DESCRIPTION
## Description
- selecting billing address will now unlock move to next step action

## Related Issue
-

## Motivation and Context
bugfix after refactoring of composables

## How Has This Been Tested?

1. add the product to the cart
2. fill user data form and go to the shipping step
3. fill in shipping address
4. select shipping method
5. go to the billing step
6. fill in billing address or select “My billing and shipping address are the same” 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
