### PR TITLE
fix(notification): remove notification cookie once the message is displayed

### DIFF
--- a/packages/theme/composables/useUiNotification/index.ts
+++ b/packages/theme/composables/useUiNotification/index.ts
@@ -58,6 +58,7 @@ const useUiNotification = () => {
 
   if (cookieMessage) {
     send(cookieMessage);
+    app.$cookies.remove(cookieNames.messageCookieName);
   }
 
   return {


### PR DESCRIPTION
## Description
Once the message is displayed, the cookie with a message will be removed to avoid displaying the message endlessly.

## Related Issue
-

## Motivation and Context
bugfix

## How Has This Been Tested?

1. log in as a customer
2. remove cookie with the token
3. reload page
4. observe the message in bottom left corner
5. reload page
6. observe that the message is not there anymore

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
