### PR TITLE
refactor: removed links from order's product

### DIFF
--- a/packages/theme/pages/MyAccount/OrderHistory.vue
+++ b/packages/theme/pages/MyAccount/OrderHistory.vue
@@ -50,9 +50,7 @@
             :key="i"
           >
             <SfTableData class="products__name">
-              <nuxt-link :to="localePath('/p/'+orderGetters.getItemSku(item)+'/'+orderGetters.getItemSku(item))">
-                {{ orderGetters.getItemName(item) }}
-              </nuxt-link>
+              {{ orderGetters.getItemName(item) }}
             </SfTableData>
             <SfTableData>{{ orderGetters.getItemQty(item) }}</SfTableData>
             <SfTableData>{{ $fc(orderGetters.getItemPrice(item)) }}</SfTableData>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Products are not connected with an order, and it's hard to establish if we can link to the product, so we decided to remove links to products from order details. 

The main problem was with configurable products and the wrong SKU on the product in orders data. There was an SKU of a child, but we need the SKU of the main product. 

## Related Issue
#768

## Motivation and Context
bugfixing

## How Has This Been Tested?
Tested on my local on order details page



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
