### PR TITLE
fix(theme): remove placeholder for a sorting mechanism in the category navbar

### DIFF
--- a/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
+++ b/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
@@ -26,7 +26,6 @@
         <SfSelect
           :value="sortBy.selected"
           class="navbar__select"
-          placeholder="Select sorting"
           @input="changeSorting"
         >
           <SfSelectOption


### PR DESCRIPTION
## Description
- because we have a default sorting value, the additional placeholder is not required

## Related Issue
#774 

## Motivation and Context
Improvement

## How Has This Been Tested?
-
![Screenshot 2022-03-24 at 08 06 21](https://user-images.githubusercontent.com/16045377/159861245-2e809d85-1790-4396-93ea-2dbeeeeaca81.png)


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
