### PR TITLE
fix(theme): billing address is cleared while returning to billing step on checkout M2-333

### DIFF
--- a/packages/theme/components/Checkout/UserBillingAddresses.vue
+++ b/packages/theme/components/Checkout/UserBillingAddresses.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <SfAddressPicker
-      :selected="`${currentAddressId}`"
+      :selected="`${selectedAddress}`"
       class="billing__addresses"
       @change="setCurrentAddress($event)"
     >
@@ -27,7 +27,7 @@
 
 <script>
 import { SfCheckbox, SfAddressPicker } from '@storefront-ui/vue';
-import { defineComponent } from '@nuxtjs/composition-api';
+import { computed, defineComponent } from '@nuxtjs/composition-api';
 import { userBillingGetters } from '~/getters';
 import UserAddressDetails from '~/components/UserAddressDetails.vue';
 
@@ -63,7 +63,14 @@ export default defineComponent({
       emit('setCurrentAddress', selectedAddress);
     };
 
+    const selectedAddress = computed(() => (
+      props.currentAddressId
+        ? props.currentAddressId
+        : props.billingAddresses.find((address) => address.default_billing)?.id ?? ''
+    ));
+
     return {
+      selectedAddress,
       setCurrentAddress,
       userBillingGetters,
     };

--- a/packages/theme/pages/Checkout/Billing.vue
+++ b/packages/theme/pages/Checkout/Billing.vue
@@ -334,7 +334,7 @@ export default defineComponent({
     const userBilling = ref({});
 
     const {
-      save, loading,
+      save, load: loadBilling, loading,
     } = useBilling();
     const {
       load: loadUserBilling,
@@ -374,8 +374,10 @@ export default defineComponent({
       return addresses.value.length > 0;
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const countriesList = computed(() => addressGetter.countriesList(countries.value));
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const regionInformation = computed(() => addressGetter.regionList(country.value));
 
     const handleAddressSubmit = (reset) => async () => {
@@ -475,7 +477,10 @@ export default defineComponent({
         await router.push(app.localePath('/checkout/user-account'));
       }
 
-      countries.value = await loadCountries();
+      const [loadedCountries, loadedBilling] = await Promise.all([loadCountries(), loadBilling()]);
+      countries.value = loadedCountries;
+      billingAddress.value = loadedBilling;
+
       if (billingDetails.value?.country_code) {
         country.value = await searchCountry({ id: billingDetails.value.country_code });
       }


### PR DESCRIPTION
## Description
- add billing address persistence by loading once the step is mounted
- add selection of default address if none is selected

## Related Issue
#773 

## Motivation and Context
bugfix

## How Has This Been Tested?

1. Add product to cart and proceed to checkout
2. On ‘Billing’ step add new billing address
3. Proceed to ‘Payment’ step
4. Go back from ‘Payment’ step to ‘Billing’ step

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
