### PR TITLE
chore: run eslint only 1 time instead of 3 times

### DIFF
--- a/packages/api-client/.lintstagedrc
+++ b/packages/api-client/.lintstagedrc
@@ -1,8 +1,3 @@
 {
-  "*.{js,jsx}": [
-    "eslint --fix"
-  ],
-  "*.{ts,tsx}": [
-    "eslint --fix"
-  ],
+  "*.{js,jsx,ts,tsx}": "eslint --fix"
 }

--- a/packages/composables/.lintstagedrc
+++ b/packages/composables/.lintstagedrc
@@ -1,8 +1,3 @@
 {
-  "*.{js,jsx}": [
-    "eslint --fix"
-  ],
-  "*.{ts,tsx}": [
-    "eslint --fix"
-  ],
+  "*.{js,jsx,ts,tsx}": "eslint --fix"
 }

--- a/packages/theme/.lintstagedrc
+++ b/packages/theme/.lintstagedrc
@@ -1,11 +1,3 @@
 {
-  "*.{js,jsx}": [
-    "eslint --fix"
-  ],
-  "*.{ts,tsx}": [
-    "eslint --fix"
-  ],
-  "*.vue": [
-    "eslint --fix"
-  ],
+  "*.{js,jsx,ts,tsx,vue}": "eslint --fix" 
 }


### PR DESCRIPTION
M2-345

I assume that under the hood lintstaged rc runs eslint three times for each file extension group instead of just once for all files. This slows things down a bit. I don't think there's much benefit of separating js ts and vue files into groups. I checked and the PR makes things a little faster

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
