### PR TITLE
fix(category): move products loading to onMount hook to avoid caching prices

### DIFF
--- a/packages/theme/components/MobileStoreBanner.vue
+++ b/packages/theme/components/MobileStoreBanner.vue
@@ -7,10 +7,11 @@
   >
     <template #call-to-action>
       <div class="app-banner__call-to-action">
-        <SfButton
+        <SfLink
           class="app-banner__button sf-banner__call-to-action"
           aria-label="Go to Apple Product"
           data-testid="banner-cta-button"
+          link="#"
         >
           <SfImage
             src="/homepage/apple.png"
@@ -19,11 +20,12 @@
             :width="134"
             :height="44"
           />
-        </SfButton>
-        <SfButton
+        </SfLink>
+        <SfLink
           class="app-banner__button sf-banner__call-to-action"
           aria-label="Go to Google Product"
           data-testid="banner-cta-button"
+          link="#"
         >
           <SfImage
             src="/homepage/google.png"
@@ -32,7 +34,7 @@
             :width="134"
             :height="44"
           />
-        </SfButton>
+        </SfLink>
       </div>
     </template>
   </SfBanner>
@@ -40,7 +42,7 @@
 <script type="module">
 import {
   SfBanner,
-  SfButton,
+  SfLink,
   SfImage,
 } from '@storefront-ui/vue';
 import { defineComponent } from '@nuxtjs/composition-api';
@@ -49,7 +51,7 @@ export default defineComponent({
   name: 'AppStoreBanner',
   components: {
     SfBanner,
-    SfButton,
+    SfLink,
     SfImage,
   },
 });

--- a/packages/theme/components/RelatedProducts.vue
+++ b/packages/theme/components/RelatedProducts.vue
@@ -6,7 +6,9 @@
   />
 </template>
 <script>
-import { defineComponent, useFetch, ref } from '@nuxtjs/composition-api';
+import {
+  defineComponent, ref, onMounted,
+} from '@nuxtjs/composition-api';
 import { useRelatedProducts } from '~/composables';
 import ProductsCarousel from '~/components/ProductsCarousel.vue';
 import { productData } from '~/helpers/product/productData';
@@ -24,7 +26,7 @@ export default defineComponent({
     } = useRelatedProducts();
     const products = ref([]);
 
-    useFetch(async () => {
+    onMounted(async () => {
       const baseSearchQuery = {
         filter: {
           sku: {

--- a/packages/theme/components/UpsellProducts.vue
+++ b/packages/theme/components/UpsellProducts.vue
@@ -6,7 +6,7 @@
   />
 </template>
 <script>
-import { defineComponent, useFetch, ref } from '@nuxtjs/composition-api';
+import { defineComponent, ref, onMounted } from '@nuxtjs/composition-api';
 import { useUpsellProducts } from '~/composables';
 import ProductsCarousel from '~/components/ProductsCarousel.vue';
 import { productData } from '~/helpers/product/productData';
@@ -21,7 +21,7 @@ export default defineComponent({
     const { search, loading } = useUpsellProducts(id);
     const products = ref([]);
 
-    useFetch(async () => {
+    onMounted(async () => {
       const baseSearchQuery = {
         filter: {
           sku: {

--- a/packages/theme/composables/useApi/index.ts
+++ b/packages/theme/composables/useApi/index.ts
@@ -6,6 +6,7 @@ export const useApi = () => {
   const { app } = useContext();
   const customerToken = app.$cookies.get(cookieNames.customerCookieName);
   const storeCode = app.$cookies.get(cookieNames.storeCookieName);
+  const currency = app.$cookies.get(cookieNames.currencyCookieName);
   const magentoConfig = app.$vsf.$magento.config;
   // TODO remove once we remove apollo client
   const { useGETForQueries } = magentoConfig.customApolloHttpLinkOptions;
@@ -13,6 +14,7 @@ export const useApi = () => {
   const defaultHeaders: {
     authorization?: string,
     store?: string
+    'Content-Currency'?: string
   } = {};
 
   if (customerToken) {
@@ -21,6 +23,10 @@ export const useApi = () => {
 
   if (storeCode) {
     defaultHeaders.store = storeCode;
+  }
+
+  if (currency) {
+    defaultHeaders['Content-Currency'] = currency;
   }
 
   const query = (

--- a/packages/theme/modules/catalog/pricing/__tests__/usePrice.spec.js
+++ b/packages/theme/modules/catalog/pricing/__tests__/usePrice.spec.js
@@ -1,0 +1,48 @@
+import { usePrice } from '~/modules/catalog/pricing/usePrice';
+import { useApi } from '~/composables/useApi';
+import getPricesQuery from '~/modules/catalog/pricing/getPricesQuery.gql';
+
+jest.mock('~/composables/useApi', () => ({
+  useApi: jest.fn(),
+}));
+
+describe('usePrice', () => {
+  it('Factory returns required methods', () => {
+    const actual = usePrice();
+    expect(actual).toHaveProperty('getPricesBySku');
+    expect(actual).toHaveProperty('getPrices');
+  });
+
+  it('getPrices', async () => {
+    const { getPrices } = usePrice();
+    const pageSize = 20;
+    const currentPage = 1;
+    const variables = { filter: { sku: { eq: 'test' } }, pageSize, currentPage };
+    const expectedResult = { items: [] };
+    const useApiMock = { query: jest.fn(() => (expectedResult)) };
+
+    useApi.mockReturnValue(useApiMock);
+    const actualResult = await getPrices(variables);
+
+    expect(useApiMock.query).toBeCalledTimes(1);
+    expect(useApiMock.query).toBeCalledWith(getPricesQuery, variables);
+    expect(expectedResult).toMatchObject(actualResult);
+  });
+
+  it('getPricesBySku', async () => {
+    const { getPricesBySku } = usePrice();
+    const pageSize = 20;
+    const currentPage = 1;
+    const skus = ['sku1', 'sku2'];
+    const expectedVariables = { filter: { sku: { in: skus } }, pageSize, currentPage };
+    const expectedResult = { items: [] };
+    const useApiMock = { query: jest.fn(() => (expectedResult)) };
+
+    useApi.mockReturnValue(useApiMock);
+    const actualResult = await getPricesBySku(skus, pageSize, currentPage);
+
+    expect(useApiMock.query).toBeCalledTimes(1);
+    expect(useApiMock.query).toBeCalledWith(getPricesQuery, expectedVariables);
+    expect(expectedResult).toMatchObject(actualResult);
+  });
+});

--- a/packages/theme/modules/catalog/pricing/getPricesQuery.gql.ts
+++ b/packages/theme/modules/catalog/pricing/getPricesQuery.gql.ts
@@ -1,0 +1,33 @@
+import { gql } from 'graphql-request';
+
+export default gql`
+  query productsList($search: String = "", $filter: ProductAttributeFilterInput, $pageSize: Int = 20, $currentPage: Int = 1, $sort: ProductAttributeSortInput) {
+    products(search: $search, filter: $filter, pageSize: $pageSize, currentPage: $currentPage, sort: $sort) {
+      items {
+        sku
+        price_range {
+          maximum_price {
+            final_price {
+              currency
+              value
+            }
+            regular_price {
+              currency
+              value
+            }
+          }
+          minimum_price {
+            final_price {
+              currency
+              value
+            }
+            regular_price {
+              currency
+              value
+            }
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/theme/modules/catalog/pricing/usePrice.ts
+++ b/packages/theme/modules/catalog/pricing/usePrice.ts
@@ -1,0 +1,28 @@
+import { useApi } from '~/composables/useApi';
+import getPricesQuery from '~/modules/catalog/pricing/getPricesQuery.gql';
+import { PriceRange } from '~/modules/GraphQL/types';
+import { GetProductSearchParams } from '~/composables/types';
+
+export interface PriceItem {
+  price_range: PriceRange;
+  sku: String;
+}
+
+export interface PriceItems {
+  items: PriceItem[]
+}
+
+export const usePrice = () => {
+  const getPrices = async (variables: GetProductSearchParams): Promise<PriceItems> => {
+    const { query } = useApi();
+    const { products } = await query(getPricesQuery, variables);
+
+    return products ?? { items: [] };
+  };
+
+  const getPricesBySku = async (skus: string[], pageSize = 20, currentPage = 1): Promise<PriceItems> => getPrices(
+    { filter: { sku: { in: skus } }, pageSize, currentPage },
+  );
+
+  return { getPricesBySku, getPrices };
+};

--- a/packages/theme/pages/Home.vue
+++ b/packages/theme/pages/Home.vue
@@ -99,11 +99,10 @@ import {
 } from '@storefront-ui/vue';
 
 import {
-  computed,
   defineComponent,
   ref,
   useContext,
-  useAsync,
+  onMounted,
 } from '@nuxtjs/composition-api';
 import LazyHydrate from 'vue-lazy-hydration';
 import { useCache, CacheTagPrefix } from '@vue-storefront/cache';
@@ -134,6 +133,7 @@ export default defineComponent({
     const { app } = useContext();
     const year = new Date().getFullYear();
     const { getProductList, loading: newProductsLoading } = useProduct();
+    const newProducts = ref([]);
     const heroes = ref([
       {
         title: app.i18n.t('Colorful summer dresses are already in store'),
@@ -240,7 +240,7 @@ export default defineComponent({
       },
     ]);
 
-    const products = useAsync(async () => {
+    onMounted(async () => {
       const productsData = await getProductList({
         pageSize: 10,
         currentPage: 1,
@@ -250,12 +250,11 @@ export default defineComponent({
       });
 
       addTags([{ prefix: CacheTagPrefix.View, value: 'home' }]);
-      return productsData;
+
+      newProducts.value = productGetters.getFiltered(productsData?.items, { master: true });
     });
 
     // @ts-ignore
-    const newProducts = computed(() => productGetters.getFiltered(products.value?.items, { master: true }));
-
     return {
       banners,
       heroes,


### PR DESCRIPTION
## Description

- refactor(prices): make prices non-cachable
    - add usePrice composable in catalog module
    - rework the category page to load prices onMounted lifecycle to avoid caching

- refactor(home): make new product carousel non cachable
    - load products data onMounted to avoid price caching

- fix(theme): mobile store banner
    - replace SfButton with SfLink so we can have images inside elements without breaking hydration

- refactor(theme): change the way related and upsell products are loaded
    - upsell/related products on the PDP will be now loaded onMounted hook


## How Has This Been Tested?

1. go to any page with prices
2. switch the currency
3. observe if price is recalculated according to the rates configured in magento

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
