### PR TITLE
refactor: unify cookie retrieval

### DIFF
--- a/packages/api-client/src/helpers/apiClient/defaultSettings.ts
+++ b/packages/api-client/src/helpers/apiClient/defaultSettings.ts
@@ -23,6 +23,9 @@ export const defaultSettings: ClientConfig = {
     setLocale: () => {},
     getCountry: () => '',
     setCountry: () => {},
+    setMessage: () => {},
+    // @ts-ignore
+    getMessage: () => ({}),
   },
   externalCheckout: {
     enable: false,

--- a/packages/api-client/src/types/setup.ts
+++ b/packages/api-client/src/types/setup.ts
@@ -48,6 +48,8 @@ export type ConfigState = {
   setLocale(id?: string | null): void;
   getCountry(): string;
   setCountry(id?: string | null): void;
+  getMessage<T>(): T;
+  setMessage<T>(id?: T | null): void;
 };
 
 export interface ClientConfig {

--- a/packages/api-client/src/types/setup.ts
+++ b/packages/api-client/src/types/setup.ts
@@ -38,18 +38,25 @@ export type Store = {
 export type ConfigState = {
   getCartId(): string;
   setCartId(id?: string | null): void;
+  removeCartId(): void;
   getCustomerToken(): string;
   setCustomerToken(token?: string | null): void;
+  removeCustomerToken(): void;
   getStore(): string;
   setStore(id?: string | null): void;
+  removeStore(): void;
   getCurrency(): string;
   setCurrency(id?: string | null): void;
+  removeCurrency(): void;
   getLocale(): string;
   setLocale(id?: string | null): void;
+  removeLocale(): void;
   getCountry(): string;
   setCountry(id?: string | null): void;
+  removeCountry(): void;
   getMessage<T>(): T;
   setMessage<T>(id?: T | null): void;
+  removeMessage(): void;
 };
 
 export interface ClientConfig {

--- a/packages/theme/composables/useApi/index.ts
+++ b/packages/theme/composables/useApi/index.ts
@@ -1,12 +1,11 @@
 import { useContext } from '@nuxtjs/composition-api';
 import { request as graphQLRequest, GraphQLClient } from 'graphql-request';
-import cookieNames from '~/enums/cookieNameEnum';
 
 export const useApi = () => {
   const { app } = useContext();
-  const customerToken = app.$cookies.get(cookieNames.customerCookieName);
-  const storeCode = app.$cookies.get(cookieNames.storeCookieName);
-  const currency = app.$cookies.get(cookieNames.currencyCookieName);
+  const customerToken = app.$vsf.$magento.config.state.getCustomerToken();
+  const storeCode = app.$vsf.$magento.config.state.getStore();
+  const currency = app.$vsf.$magento.config.state.getCurrency();
   const magentoConfig = app.$vsf.$magento.config;
   // TODO remove once we remove apollo client
   const { useGETForQueries } = magentoConfig.customApolloHttpLinkOptions;

--- a/packages/theme/composables/useMagentoConfiguration.ts
+++ b/packages/theme/composables/useMagentoConfiguration.ts
@@ -2,7 +2,6 @@ import { computed, ComputedRef, useContext } from '@nuxtjs/composition-api';
 import { StoreConfig } from '~/modules/GraphQL/types';
 import { storeConfigGetters } from '~/getters';
 
-import cookieNames from '~/enums/cookieNameEnum';
 import { useConfig } from '~/composables';
 
 type UseMagentoConfiguration = () => {
@@ -22,9 +21,9 @@ export const useMagentoConfiguration: UseMagentoConfiguration = () => {
     load: loadConfig,
   } = useConfig();
 
-  const selectedCurrency = computed<string | undefined>(() => app.$cookies.get(cookieNames.currencyCookieName));
-  const selectedLocale = computed<string | undefined>(() => app.$cookies.get(cookieNames.localeCookieName));
-  const selectedStore = computed<string | undefined>(() => app.$cookies.get(cookieNames.storeCookieName));
+  const selectedCurrency = computed<string | undefined>(() => app.$vsf.$magento.config.state.getCurrency());
+  const selectedLocale = computed<string | undefined>(() => app.$vsf.$magento.config.state.getLocale());
+  const selectedStore = computed<string | undefined>(() => app.$vsf.$magento.config.state.getStore());
 
   const loadConfiguration: (params: { updateCookies: boolean; updateLocale: boolean; }) => void = (params = {
     updateCookies: false,
@@ -37,25 +36,19 @@ export const useMagentoConfiguration: UseMagentoConfiguration = () => {
 
     // eslint-disable-next-line promise/catch-or-return
     loadConfig().then(() => {
-      if (!app.$cookies.get(cookieNames.storeCookieName) || updateCookies) {
-        app.$cookies.set(
-          cookieNames.storeCookieName,
-          storeConfigGetters.getCode(storeConfig.value as StoreConfig),
-        );
+      if (!app.$vsf.$magento.config.state.getStore() || updateCookies) {
+        // @ts-ignore
+        app.$vsf.$magento.config.state.setStore(storeConfig.value);
       }
 
-      if (!app.$cookies.get(cookieNames.localeCookieName) || updateCookies) {
-        app.$cookies.set(
-          cookieNames.localeCookieName,
-          storeConfigGetters.getCode(storeConfig.value as StoreConfig),
-        );
+      if (!app.$vsf.$magento.config.state.getLocale() || updateCookies) {
+        // @ts-ignore
+        app.$vsf.$magento.config.state.setLocale(storeConfig.value);
       }
 
-      if (!app.$cookies.get(cookieNames.currencyCookieName) || updateCookies) {
-        app.$cookies.set(
-          cookieNames.currencyCookieName,
-          storeConfigGetters.getCurrency(storeConfig.value as StoreConfig),
-        );
+      if (!app.$vsf.$magento.config.state.getCurrency() || updateCookies) {
+        // @ts-ignore
+        app.$vsf.$magento.config.state.setCurrency(storeConfig.value);
       }
 
       if (updateLocale) {

--- a/packages/theme/composables/useUiNotification/index.ts
+++ b/packages/theme/composables/useUiNotification/index.ts
@@ -1,17 +1,17 @@
 import { computed, reactive, useContext } from '@nuxtjs/composition-api';
-import cookieNames from '~/enums/cookieNameEnum';
 
-interface UiNotification {
+type UiNotificationType = 'secondary' | 'info' | 'success' | 'warning' | 'danger';
+
+export interface UiNotification {
   message: string;
   title?: string;
   action?: { text: string; onClick: (...args: any) => void };
-  type: 'danger' | 'success' | 'info';
+  type: UiNotificationType;
   icon: string;
   persist?: boolean;
   id: symbol;
   dismiss?: () => void;
 }
-
 interface Notifications {
   notifications: Array<UiNotification>;
 }
@@ -24,7 +24,7 @@ const timeToLive = 3000;
 
 const useUiNotification = () => {
   const { app } = useContext();
-  const cookieMessage: UiNotification = app.$cookies.get(cookieNames.messageCookieName);
+  const cookieMessage = app.$vsf.$magento.config.state.getMessage<UiNotification>();
 
   const send = (notification: UiNotification) => {
     const id = Symbol('id');
@@ -34,7 +34,7 @@ const useUiNotification = () => {
 
       if (index !== -1) state.notifications.splice(index, 1);
 
-      app.$cookies.remove(cookieNames.messageCookieName);
+      app.$vsf.$magento.config.state.setMessage();
     };
 
     const newNotification = {
@@ -58,7 +58,7 @@ const useUiNotification = () => {
 
   if (cookieMessage) {
     send(cookieMessage);
-    app.$cookies.remove(cookieNames.messageCookieName);
+    app.$vsf.$magento.config.state.setMessage();
   }
 
   return {

--- a/packages/theme/composables/useUiNotification/index.ts
+++ b/packages/theme/composables/useUiNotification/index.ts
@@ -34,7 +34,7 @@ const useUiNotification = () => {
 
       if (index !== -1) state.notifications.splice(index, 1);
 
-      app.$vsf.$magento.config.state.setMessage();
+      app.$vsf.$magento.config.state.removeMessage();
     };
 
     const newNotification = {
@@ -58,7 +58,7 @@ const useUiNotification = () => {
 
   if (cookieMessage) {
     send(cookieMessage);
-    app.$vsf.$magento.config.state.setMessage();
+    app.$vsf.$magento.config.state.removeMessage();
   }
 
   return {

--- a/packages/theme/composables/useWishlist/index.ts
+++ b/packages/theme/composables/useWishlist/index.ts
@@ -1,6 +1,5 @@
 import { ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
-import cookieNames from '~/enums/cookieNameEnum';
 import { CustomQuery } from '~/composables/types';
 import { useCustomerStore } from '~/stores/customer';
 import { findItemOnWishlist } from '~/composables/useWishlist/helpers';
@@ -156,7 +155,7 @@ export const useWishlist = (): UseWishlist => {
         });
       }
 
-      if (!app.context.$cookies.get(cookieNames.customerCookieName)) { // TODO: replace by value from pinia store after sueCart composable will be refactored
+      if (!app.$vsf.$magento.config.state.getCustomerToken()) { // TODO: replace by value from pinia store after sueCart composable will be refactored
         Logger.error('Need to be authenticated to add a product to wishlist');
       }
 

--- a/packages/theme/middleware/checkout.ts
+++ b/packages/theme/middleware/checkout.ts
@@ -1,5 +1,8 @@
+import { Middleware } from '@nuxt/types';
 import { Logger } from '~/helpers/logger';
 
-export default () => {
+const middleware : Middleware = () => {
   Logger.error('Please implement vendor-specific checkout.js middleware in the \'middleware\' directory to block access to checkout steps when customer did not yet complete previous steps');
 };
+
+export default middleware;

--- a/packages/theme/middleware/is-authenticated.js
+++ b/packages/theme/middleware/is-authenticated.js
@@ -1,5 +1,0 @@
-export default async ({ app, redirect }) => {
-  if (!app.$cookies.get('vsf-customer')) {
-    return redirect('/');
-  }
-};

--- a/packages/theme/middleware/is-authenticated.ts
+++ b/packages/theme/middleware/is-authenticated.ts
@@ -1,0 +1,8 @@
+import { Middleware } from '@nuxt/types';
+
+const middleware : Middleware = (context) => {
+  if (!context.app.$vsf.$magento.config.state.getCustomerToken()) {
+    context.redirect('/');
+  }
+};
+export default middleware;

--- a/packages/theme/modules/magento/defaultConfig.ts
+++ b/packages/theme/modules/magento/defaultConfig.ts
@@ -1,4 +1,4 @@
-export const defaultConfig : Record<string, any> = {
+export const defaultConfig = {
   cookies: {
     currencyCookieName: 'vsf-currency',
     countryCookieName: 'vsf-country',
@@ -8,4 +8,7 @@ export const defaultConfig : Record<string, any> = {
     storeCookieName: 'vsf-store',
     messageCookieName: 'vsf-message',
   },
-};
+  locale: undefined,
+  country: undefined,
+  currency: undefined,
+} as const;

--- a/packages/theme/modules/magento/helpers/index.ts
+++ b/packages/theme/modules/magento/helpers/index.ts
@@ -1,26 +1,24 @@
 import { defaultConfig } from '~/modules/magento/defaultConfig';
 
-export const getLocaleSettings = (app, moduleOptions) => {
-  let localeSettings : Record<string, string> = {};
-
-  if (moduleOptions.cookies) {
-    localeSettings = {
-      locale: app.$cookies.get(moduleOptions.cookies.localeCookieName),
-      country: app.$cookies.get(moduleOptions.cookies.countryCookieName),
-      currency: app.$cookies.get(moduleOptions.cookies.currencyCookieName),
-    };
-  }
+export const getLocaleSettings = (app, moduleOptions, additionalProperties) => {
+  const localeSettings = moduleOptions.cookies
+    ? {
+      currency: additionalProperties.state.getCurrency(),
+      locale: additionalProperties.state.getLocale(),
+      country: additionalProperties.state.getCountry(),
+    }
+    : {};
 
   return {
-    locale: app.i18n.locale || (localeSettings.locale || moduleOptions.locale || defaultConfig.locale || undefined),
-    country: localeSettings.country || moduleOptions.country || defaultConfig.country || undefined,
     currency: localeSettings.currency || moduleOptions.currency || defaultConfig.currency || undefined,
+    locale: app.i18n.locale || localeSettings.locale || moduleOptions.locale || defaultConfig.locale || undefined,
+    country: localeSettings.country || moduleOptions.country || defaultConfig.country || undefined,
   };
 };
 
-export const mapConfigToSetupObject = ({ moduleOptions, app, additionalProperties = {} }) => ({
+export const mapConfigToSetupObject = ({ app, moduleOptions, additionalProperties = {} }) => ({
   ...defaultConfig,
   ...moduleOptions,
   ...additionalProperties,
-  ...getLocaleSettings(app, moduleOptions),
+  ...getLocaleSettings(app, moduleOptions, additionalProperties),
 });

--- a/packages/theme/modules/magento/plugin.ts
+++ b/packages/theme/modules/magento/plugin.ts
@@ -65,6 +65,5 @@ export default integrationPlugin((plugin) => {
     },
   });
 
-  // @ts-ignore - not typed in core
   plugin.integration.configure('magento', settings);
 });

--- a/packages/theme/modules/magento/plugin.ts
+++ b/packages/theme/modules/magento/plugin.ts
@@ -1,58 +1,66 @@
+import type { NuxtCookies } from 'cookie-universal-nuxt';
 import { integrationPlugin } from '~/helpers/integrationPlugin';
 import { mapConfigToSetupObject } from '~/modules/magento/helpers';
 import { defaultConfig } from '~/modules/magento/defaultConfig';
 
 const moduleOptions = JSON.parse('<%= JSON.stringify(options) %>');
 
-// TODO should be moved to THEME and expose consistent cookie management API
 export default integrationPlugin((plugin) => {
-  const cartCookieName : string = moduleOptions.cookies?.cartCookieName || defaultConfig.cookies.cartCookieName;
-  const customerCookieName : string = moduleOptions.cookies?.customerCookieName || defaultConfig.cookies.customerCookieName;
-  const storeCookieName : string = moduleOptions.cookies?.storeCookieName || defaultConfig.cookies.storeCookieName;
-  const currencyCookieName : string = moduleOptions.cookies?.currencyCookieName || defaultConfig.cookies.currencyCookieName;
-  const localeCookieName : string = moduleOptions.cookies?.localeCookieName || defaultConfig.cookies.localeCookieName;
-  const countryCookieName : string = moduleOptions.cookies?.countryCookieName || defaultConfig.cookies.countryCookieName;
+  const getCookieName = (property: string) : string => moduleOptions.cookies?.[property] ?? defaultConfig.cookies[property];
+
+  const cookieNames = {
+    cart: getCookieName('cartCookieName'),
+    customer: getCookieName('customerCookieName'),
+    currency: getCookieName('currencyCookieName'),
+    store: getCookieName('storeCookieName'),
+    locale: getCookieName('localeCookieName'),
+    country: getCookieName('countryCookieName'),
+    message: getCookieName('messageCookieName'),
+  };
 
   const { $cookies } = plugin.app;
 
-  const getCartId = () => $cookies.get(cartCookieName);
-  const setCartId = (id: string) => (!id ? $cookies.remove(cartCookieName) : $cookies.set(cartCookieName, id));
+  const createCookieOperationsInstance = (cookies: NuxtCookies) => (cookieName: string) => ({
+    get: () => cookies.get(cookieName),
+    set: (value: string) => (value
+      ? cookies.set(cookieName, value)
+      : cookies.remove(cookieName)),
+  });
+  const createCookieOperations = createCookieOperationsInstance($cookies);
 
-  const getCustomerToken = () => $cookies.get(customerCookieName);
-  const setCustomerToken = (token: string) => (!token ? $cookies.remove(customerCookieName) : $cookies.set(customerCookieName, token));
-
-  const getStore = () => $cookies.get(storeCookieName);
-  const setStore = (store: string) => (!store ? $cookies.remove(storeCookieName) : $cookies.set(storeCookieName, store));
-
-  const getCurrency = () => $cookies.get(currencyCookieName);
-  const setCurrency = (currency: string) => (!currency ? $cookies.remove(currencyCookieName) : $cookies.set(currencyCookieName, currency));
-
-  const getLocale = () => $cookies.get(localeCookieName);
-  const setLocale = (locale: string) => (!locale ? $cookies.remove(localeCookieName) : $cookies.set(localeCookieName, locale));
-
-  const getCountry = () => $cookies.get(countryCookieName);
-  const setCountry = (country: string) => (!country ? $cookies.remove(countryCookieName) : $cookies.set(countryCookieName, country));
+  const { get: getCartId, set: setCartId } = createCookieOperations(cookieNames.cart);
+  const { get: getCustomerToken, set: setCustomerToken } = createCookieOperations(cookieNames.customer);
+  const { get: getStore, set: setStore } = createCookieOperations(cookieNames.store);
+  const { get: getCurrency, set: setCurrency } = createCookieOperations(cookieNames.currency);
+  const { get: getLocale, set: setLocale } = createCookieOperations(cookieNames.locale);
+  const { get: getCountry, set: setCountry } = createCookieOperations(cookieNames.country);
+  const { get: getMessage, set: setMessage } = createCookieOperations(cookieNames.message);
 
   const settings = mapConfigToSetupObject({
     moduleOptions,
     app: plugin.app,
     additionalProperties: {
       state: {
-        // Cart
         getCartId,
         setCartId,
-        // Customer
+
         getCustomerToken,
         setCustomerToken,
-        // Store
+
         getStore,
         setStore,
+
         getCurrency,
         setCurrency,
+
         getLocale,
         setLocale,
+
         getCountry,
         setCountry,
+
+        getMessage,
+        setMessage,
       },
     },
   });

--- a/packages/theme/modules/magento/plugin.ts
+++ b/packages/theme/modules/magento/plugin.ts
@@ -1,4 +1,5 @@
-import type { NuxtCookies } from 'cookie-universal-nuxt';
+import type { NuxtCookies, GetOptions } from 'cookie-universal-nuxt';
+import type { CookieSerializeOptions } from 'cookie';
 import { integrationPlugin } from '~/helpers/integrationPlugin';
 import { mapConfigToSetupObject } from '~/modules/magento/helpers';
 import { defaultConfig } from '~/modules/magento/defaultConfig';
@@ -20,11 +21,10 @@ export default integrationPlugin((plugin) => {
 
   const { $cookies } = plugin.app;
 
-  const createCookieOperationsInstance = (cookies: NuxtCookies) => (cookieName: string) => ({
-    get: () => cookies.get(cookieName),
-    set: (value: string) => (value
-      ? cookies.set(cookieName, value)
-      : cookies.remove(cookieName)),
+  const createCookieOperationsInstance = <TValue = string>(cookies: NuxtCookies) => (cookieName: string) => ({
+    get: (opts?: GetOptions) => cookies.get(cookieName, opts),
+    set: (value: TValue, opts?: CookieSerializeOptions) => cookies.set(cookieName, value, opts),
+    remove: (opts?: CookieSerializeOptions) => cookies.remove(cookieName, opts),
   });
   const createCookieOperations = createCookieOperationsInstance($cookies);
 

--- a/packages/theme/modules/magento/plugin.ts
+++ b/packages/theme/modules/magento/plugin.ts
@@ -26,15 +26,52 @@ export default integrationPlugin((plugin) => {
     set: (value: TValue, opts?: CookieSerializeOptions) => cookies.set(cookieName, value, opts),
     remove: (opts?: CookieSerializeOptions) => cookies.remove(cookieName, opts),
   });
+
   const createCookieOperations = createCookieOperationsInstance($cookies);
 
-  const { get: getCartId, set: setCartId } = createCookieOperations(cookieNames.cart);
-  const { get: getCustomerToken, set: setCustomerToken } = createCookieOperations(cookieNames.customer);
-  const { get: getStore, set: setStore } = createCookieOperations(cookieNames.store);
-  const { get: getCurrency, set: setCurrency } = createCookieOperations(cookieNames.currency);
-  const { get: getLocale, set: setLocale } = createCookieOperations(cookieNames.locale);
-  const { get: getCountry, set: setCountry } = createCookieOperations(cookieNames.country);
-  const { get: getMessage, set: setMessage } = createCookieOperations(cookieNames.message);
+  // TODO Refactor to separate containers (state.cart.get() .set() .remove()) - this requires a breaking change in api-client types
+
+  const {
+    get: getCartId,
+    set: setCartId,
+    remove: removeCartId,
+  } = createCookieOperations(cookieNames.cart);
+
+  const {
+    get: getCustomerToken,
+    set: setCustomerToken,
+    remove: removeCustomerToken,
+  } = createCookieOperations(cookieNames.customer);
+
+  const {
+    get: getStore,
+    set: setStore,
+    remove: removeStore,
+  } = createCookieOperations(cookieNames.store);
+
+  const {
+    get: getCurrency,
+    set: setCurrency,
+    remove: removeCurrency,
+  } = createCookieOperations(cookieNames.currency);
+
+  const {
+    get: getLocale,
+    set: setLocale,
+    remove: removeLocale,
+  } = createCookieOperations(cookieNames.locale);
+
+  const {
+    get: getCountry,
+    set: setCountry,
+    remove: removeCountry,
+  } = createCookieOperations(cookieNames.country);
+
+  const {
+    get: getMessage,
+    set: setMessage,
+    remove: removeMessage,
+  } = createCookieOperations(cookieNames.message);
 
   const settings = mapConfigToSetupObject({
     moduleOptions,
@@ -43,24 +80,31 @@ export default integrationPlugin((plugin) => {
       state: {
         getCartId,
         setCartId,
+        removeCartId,
 
         getCustomerToken,
         setCustomerToken,
+        removeCustomerToken,
 
         getStore,
         setStore,
+        removeStore,
 
         getCurrency,
         setCurrency,
+        removeCurrency,
 
         getLocale,
         setLocale,
+        removeLocale,
 
         getCountry,
         setCountry,
+        removeCountry,
 
         getMessage,
         setMessage,
+        removeMessage,
       },
     },
   });

--- a/packages/theme/plugins/__tests__/i18n.spec.js
+++ b/packages/theme/plugins/__tests__/i18n.spec.js
@@ -33,12 +33,9 @@ const callbackRequest = {
 };
 
 const routeMock = {
-  path: 'https://domain/german',
+  path: '/german',
 };
 const appMock = {
-  $cookies: {
-    get: jest.fn(),
-  },
   i18n: {
     defaultLocale: 'en',
     defaultCurrency: 'EUR',
@@ -61,7 +58,9 @@ const appMock = {
         state: {
           ...apiStateMock,
           setStore: jest.fn(),
+          getStore: jest.fn(),
           setLocale: jest.fn(),
+          getLocale: jest.fn(),
           setCurrency: jest.fn(),
         },
         axios: {
@@ -82,24 +81,22 @@ describe('i18n plugin', () => {
   it('Should read vsf-store cookie value', () => {
     i18nPlugin({ app: appMock, route: routeMock });
 
-    expect(appMock.$cookies.get).toHaveBeenCalledWith('vsf-store');
+    expect(appMock.$vsf.$magento.config.state.getStore).toHaveBeenCalled();
   });
 
   it('Should find locale based on magento store code', () => {
-    appMock.$cookies.get.mockReturnValue('default');
+    appMock.$vsf.$magento.config.state.getStore.mockReturnValue('default');
     i18nPlugin({ app: appMock, route: routeMock });
 
     expect(appMock.i18n.setLocale).not.toHaveBeenCalled();
   });
 
   it('Should set default locale when there is no locale that match given magento store code', () => {
-    appMock.$cookies.get.mockReturnValue('pl_PL');
-
-    expect(appMock.i18n.setLocale).not.toHaveBeenCalledTimes(1);
+    appMock.$vsf.$magento.config.state.getStore('pl_PL');
+    expect(appMock.i18n.setLocale).not.toHaveBeenCalled();
   });
 
-  it('Should set default locale when vsf-store cookie is not exist', () => {
-    appMock.$cookies.get.mockReturnValue(null);
+  it('Should set default locale when vsf-store cookie doesn\'t exist', () => {
     i18nPlugin({ app: appMock, route: routeMock });
 
     expect(appMock.i18n.setLocale).toHaveBeenCalledWith('en');
@@ -114,7 +111,7 @@ describe('i18n plugin', () => {
       },
     };
 
-    testCaseAppMock.$cookies.get.mockReturnValueOnce('de_DE').mockReturnValueOnce('default');
+    testCaseAppMock.$vsf.$magento.config.state.getStore.mockReturnValueOnce('de_DE').mockReturnValueOnce('default');
 
     i18nPlugin({ app: testCaseAppMock, route: routeMock });
 

--- a/packages/theme/plugins/__tests__/token-expired.spec.js
+++ b/packages/theme/plugins/__tests__/token-expired.spec.js
@@ -1,5 +1,4 @@
 import tokenExpiredPlugin from '../token-expired';
-import cookieNames from '~/enums/cookieNameEnum';
 
 const errRes = {
   data: {
@@ -31,6 +30,13 @@ const appMockFactory = (callbackResponse) => ({
           },
         },
       },
+      config: {
+        state: {
+          setCustomerToken: jest.fn(),
+          setCartId: jest.fn(),
+          setMessage: jest.fn(),
+        },
+      },
     },
   },
   $cookies: {
@@ -38,11 +44,11 @@ const appMockFactory = (callbackResponse) => ({
     set: jest.fn(),
   },
   router: {
-    go: jest.fn(),
+    push: jest.fn(),
   },
-  localePath: (t) => t,
+  localePath: jest.fn(),
   i18n: {
-    t: (t) => t,
+    t: jest.fn(),
   },
 });
 
@@ -54,36 +60,25 @@ describe('Token Expired plugin', () => {
   it('should be executed only if there is the "graphql-authorization" error', async () => {
     const appMock = appMockFactory(validRes);
 
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await tokenExpiredPlugin({ app: appMock });
 
-    expect(appMock.router.go).toHaveBeenCalledTimes(0);
+    expect(appMock.router.push).toHaveBeenCalledTimes(0);
   });
 
   it('should set message cookie', async () => {
     const appMock = appMockFactory(errRes);
 
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await tokenExpiredPlugin({ app: appMock });
 
-    const messageMock = {
-      icon: null,
-      message: 'You are not authorized, please log in.',
-      persist: true,
-      title: null,
-      type: 'warning',
-    };
-
-    expect(appMock.$cookies.set).toHaveBeenCalledWith('vsf-message', messageMock);
+    expect(appMock.$vsf.$magento.config.state.setMessage).toHaveBeenCalledWith(expect.any(Object));
   });
 
   it('should clear customer token and clear cart id', async () => {
     const appMock = appMockFactory(errRes);
 
-    // eslint-disable-next-line @typescript-eslint/await-thenable
     await tokenExpiredPlugin({ app: appMock });
 
-    expect(appMock.$cookies.remove).toHaveBeenCalledTimes(2);
-    expect(appMock.$cookies.remove).toHaveBeenCalledWith(cookieNames.customerCookieName);
+    expect(appMock.$vsf.$magento.config.state.setCustomerToken).toHaveBeenCalled();
+    expect(appMock.$vsf.$magento.config.state.setCustomerToken).toHaveBeenCalledWith();
   });
 });

--- a/packages/theme/plugins/fcPlugin.ts
+++ b/packages/theme/plugins/fcPlugin.ts
@@ -1,5 +1,5 @@
-import cookieNames from '~/enums/cookieNameEnum';
 import formatCurrency from '~/helpers/formatCurrency';
+import { Plugin } from '@nuxt/types';
 
 declare module 'vue/types/vue' {
   interface Vue {
@@ -9,12 +9,14 @@ declare module 'vue/types/vue' {
   }
 }
 
-export default ({ i18n, app }, inject) => {
+const plugin : Plugin = (context, inject) => {
   inject('fc', (value: number | string, locale?: string, options = {}): string => {
     // eslint-disable-next-line no-param-reassign
-    locale = locale || i18n?.localeProperties?.iso.replace('_', '-');
+    locale = locale || context.i18n?.localeProperties?.iso.replace('_', '-');
     // eslint-disable-next-line no-param-reassign
-    options = { currency: app.$cookies.get(cookieNames.currencyCookieName) || i18n?.localeProperties?.defaultCurrency, ...options };
+    options = { currency: context.app.$vsf.$magento.config.state.getCurrency() || context.i18n?.localeProperties?.defaultCurrency, ...options };
     return formatCurrency(value, locale, options);
   });
 };
+
+export default plugin;

--- a/packages/theme/plugins/i18n.ts
+++ b/packages/theme/plugins/i18n.ts
@@ -1,89 +1,37 @@
-import { Context, NuxtAppOptions } from '@nuxt/types';
+import { Context } from '@nuxt/types';
 import { LocaleObject } from 'nuxt-i18n';
-import cookieNames from '~/enums/cookieNameEnum';
 
-export declare type ConfigState = {
-  getCartId(): string;
-  setCartId(id?: string | null): void;
-  getCustomerToken(): string;
-  setCustomerToken(token?: string | null): void;
-  getStore(): string;
-  setStore(id?: string | null): void;
-  getCurrency(): string;
-  setCurrency(id?: string | null): void;
-  getLocale(): string;
-  setLocale(id?: string | null): void;
-  getCountry(): string;
-  setCountry(id?: string | null): void;
+const findLocaleBasedOnMagentoStoreCode = (storeCode: string, locales: Array<string | LocaleObject>) => locales.find((locale) => (typeof locale === 'string' ? locale === storeCode : locale.code === storeCode));
+
+const findCurrencyBasedOnMagentoStoreCode = (storeCode: string, locales: Array<string | LocaleObject>): string => {
+  const match = locales.find((locale) => typeof locale === 'object' && locale.code === storeCode) as LocaleObject | undefined;
+  return match?.defaultCurrency;
 };
 
-/**
- * Read vsf-store cookie value.
- *
- * @param app {NuxtAppOptions} - Nuxt App options object
- * @returns {string} - vsf-store cookie value
- */
-const readStoreCookie = (app: NuxtAppOptions) => app.$cookies.get(cookieNames.storeCookieName);
+export default ({ app, route }: Context) => app.$vsf.$magento.client.interceptors.request.use(async (request) => {
+  const {
+    $vsf: { $magento: { config: { state } } },
+    i18n,
+  } = app;
 
-/**
- * Find locale code based on magento store code
- * @param storeCode {string} - magento store code
- * @param locales {array} - array with locales
- * @returns string
- */
-const findLocaleBasedOnStoreCode = (storeCode: string, locales: string[] | LocaleObject[]) => {
-  if (locales.some((l) => typeof l !== 'string')) {
-    return (locales as LocaleObject[]).find((locale) => locale.code === storeCode);
+  const currentStoreCode = app.$vsf.$magento.config.state.getStore() ?? route.path.split('/')[0]; // localhost:3000/default
+  const shouldSetDefaultLocale = !currentStoreCode || !findLocaleBasedOnMagentoStoreCode(currentStoreCode, i18n.locales);
+
+  if (shouldSetDefaultLocale) {
+    await i18n.setLocale(i18n.defaultLocale);
+    return request;
   }
 
-  return (locales as string[]).find((locale) => locale === storeCode);
-};
+  const i18nCurrentLocaleCode = i18n.locale;
+  const shouldLocaleBeRefreshed = i18nCurrentLocaleCode !== state.getLocale();
 
-/**
- * Find defaultCurrency code based on magento store code
- * @param storeCode {string} - magento store code
- * @param locales {array} - array with locales
- * @returns string
- */
-const findCurrencyBasedOnStoreCode = (storeCode: string, locales: string[] | LocaleObject[]): string => {
-  const match = (locales as LocaleObject[]).find((locale) => locale.code === storeCode);
+  if (shouldLocaleBeRefreshed) {
+    const currency = findCurrencyBasedOnMagentoStoreCode(currentStoreCode, i18n.locales);
+    state.setCurrency(currency);
 
-  return match.defaultCurrency;
-};
+    state.setStore(i18nCurrentLocaleCode);
+    state.setLocale(i18nCurrentLocaleCode);
+  }
 
-/**
- * Set default locale
- * @param i18n {i18n} i18n API
- * @returns {Promise<void>}
- */
-const setDefaultLocale = async (i18n) => {
-  await i18n.setLocale(i18n.defaultLocale);
-};
-
-export default async ({ app, route }: Context) => {
-  await app.$vsf.$magento.client.interceptors.request.use(async (request) => {
-    const { i18n } = app;
-    const currentStoreCode = readStoreCookie(app) ?? route.path.split('/').find((element) => String(element));
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-    if (!currentStoreCode || !findLocaleBasedOnStoreCode(currentStoreCode, i18n.locales)) {
-      await setDefaultLocale(i18n);
-
-      return request;
-    }
-
-    const i18nCurrentLocaleCode = i18n.locale;
-
-    const localeCookie = app.$cookies.get(cookieNames.localeCookieName);
-
-    if (i18nCurrentLocaleCode !== localeCookie) {
-      const apiState = app.$vsf.$magento.config.state as ConfigState;
-      const currency = findCurrencyBasedOnStoreCode(i18nCurrentLocaleCode, i18n.locales);
-
-      apiState.setStore(i18nCurrentLocaleCode);
-      apiState.setLocale(i18nCurrentLocaleCode);
-      apiState.setCurrency(currency);
-    }
-
-    return request;
-  });
-};
+  return request;
+});

--- a/packages/theme/plugins/i18n.ts
+++ b/packages/theme/plugins/i18n.ts
@@ -1,7 +1,7 @@
 import { Context } from '@nuxt/types';
 import { LocaleObject } from 'nuxt-i18n';
 
-const findLocaleBasedOnMagentoStoreCode = (storeCode: string, locales: Array<string | LocaleObject>) => locales.find((locale) => (typeof locale === 'string' ? locale === storeCode : locale.code === storeCode));
+const findLocaleBasedOnMagentoStoreCode = (storeCode: string, locales: Array<string | LocaleObject>) => locales.find((locale) => ((typeof locale === 'object' ? locale.code : locale) === storeCode));
 
 const findCurrencyBasedOnMagentoStoreCode = (storeCode: string, locales: Array<string | LocaleObject>): string => {
   const match = locales.find((locale) => typeof locale === 'object' && locale.code === storeCode) as LocaleObject | undefined;


### PR DESCRIPTION
Up until now we've had two cookie APIs: $cookies.get/set/remove and the vue-storefront/core provided $vsf.config.state.set[CookieName]. This PR removes all instances of the first API and makes them use the $vsf.config.state API