### PR TITLE
chore: fix some "yarn install" peer dependency warnings

### DIFF
--- a/internals/eslint-vue/package.json
+++ b/internals/eslint-vue/package.json
@@ -29,6 +29,7 @@
     "rules"
   ],
   "dependencies": {
+    "@vue/eslint-config-typescript": "^10.0.0",
     "eslint-plugin-vue": "^8.4.0"
   },
   "main": "index.js"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/webpack": "^5.28.0",
     "@types/yargs": "^17.0.8",
     "@typescript-eslint/parser": "^5.10.2",
-    "@vue/eslint-config-typescript": "^10.0.0",
     "all-contributors-cli": "^6.20.0",
     "babel-eslint": "^10.1.0",
     "commitizen": "^4.2.4",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "esbuild": "^0.14.23",
     "eslint": "8.8.0",
     "execa": "^6.1.0",
+    "graphql": "^16.0.0",
     "husky": "^7.0.4",
     "jest": "^27.5.1",
     "jest-date-mock": "^1.0.8",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -55,6 +55,7 @@
     "pinia": "^2.0.11",
     "pm2": "^5.1.2",
     "vee-validate": "^3.4.14",
+    "vue": "^2.6.14",
     "vue-lazy-hydration": "^2.0.0-beta.4",
     "vue-scrollto": "^2.20.0"
   },
@@ -94,9 +95,6 @@
     "typescript": "^4.5.5",
     "vue-jest": "^3.0.7",
     "webpack": "4.46.0"
-  },
-  "peerDependencies": {
-    "vue": "^2.6.11"
   },
   "engines": {
     "node": "^16.13"

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -62,7 +62,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.12",
     "@nuxt/types": "latest",
-    "@nuxt/typescript-build": "latest",
+    "@nuxt/typescript-build": "^2.1.0",
     "@testing-library/jest-dom": "^5.16.1",
     "@testing-library/user-event": "^13.5.0",
     "@testing-library/vue": "^5.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10487,7 +10487,7 @@ graphql-ws@^5.4.1:
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.6.2.tgz#c7e5e382bd80d7fef637ea0b86ef4b1cb3d0b09b"
   integrity sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==
 
-graphql@*, graphql@^16.3.0:
+graphql@*, graphql@^16.0.0, graphql@^16.3.0:
   version "16.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.3.0.tgz#a91e24d10babf9e60c706919bb182b53ccdffc05"
   integrity sha512-xm+ANmA16BzCT5pLjuXySbQVFwH3oJctUVdy81w1sV0vBU0KgDdBGtxQOUd5zqOBk/JayAFeG8Dlmeq74rjm/A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3149,7 +3149,7 @@
     "@types/webpack-hot-middleware" "2.25.4"
     sass-loader "10.1.1"
 
-"@nuxt/typescript-build@^2.0.0", "@nuxt/typescript-build@latest":
+"@nuxt/typescript-build@^2.0.0", "@nuxt/typescript-build@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@nuxt/typescript-build/-/typescript-build-2.1.0.tgz#191fe60e942ce84a01468ba6e255744e01c7c538"
   integrity sha512-7TLMpfzgOckf3cBkzoPFns6Xl8FzY6MoFfm/5HUE47QeTWAdOG9ZFxMrVhHWieZHYUuV+k6byRtaRv4S/3R8zA==


### PR DESCRIPTION
before:
<img width="1571" alt="image" src="https://user-images.githubusercontent.com/5359825/161910569-290a7c3d-6909-4feb-8fc8-bd5a557f831d.png">

after:
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/5359825/161911548-eaa6509b-2c75-4555-9597-de4f88110638.png">


The leftover warnings require deeper changes/are more unsafe so I just wanted to push the easy ones for now