### PR TITLE
docs: fix useContent JSDoc examples

### DIFF
--- a/packages/theme/composables/useContent/index.ts
+++ b/packages/theme/composables/useContent/index.ts
@@ -30,7 +30,7 @@ import type { UseContentInterface, UseContentErrors } from './useContent';
  * ```typescript
  * import { useContent } from '~/composables';
  *
- * export function {
+ * export default {
  *   setup() {
  *     const { loading, error, loadPage, loadBlocks } = useContent();
  *   }
@@ -44,7 +44,7 @@ import type { UseContentInterface, UseContentErrors } from './useContent';
  * import { useFetch } from '@nuxtjs/composition-api';
  * import { useContent } from '~/composables';
  *
- * export function {
+ * export default {
  *   setup() {
  *     const { loading, error, loadPage } = useContent();
  *
@@ -70,7 +70,7 @@ import type { UseContentInterface, UseContentErrors } from './useContent';
  * import { useFetch, ref } from '@nuxtjs/composition-api';
  * import { useContent } from '~/composables';
  *
- * export function {
+ * export default {
  *   setup(props) {
  *     const { loadBlocks } = useContent();
  *     const blocks = ref([]);

--- a/packages/theme/composables/useContent/useContent.ts
+++ b/packages/theme/composables/useContent/useContent.ts
@@ -36,7 +36,8 @@ export interface UseContentInterface {
    * ```typescript
    * import { useFetch, ref } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
-   * export function {
+   *
+   * export default {
    *   setup() {
    *     const { loading, error, loadPage } = useContent();
    *
@@ -59,7 +60,8 @@ export interface UseContentInterface {
    * ```typescript
    * import { useAsync } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
-   * export function {
+   *
+   * export default {
    *   setup() {
    *     const { loadPage } = useContent();
    *     const pageId = 'about-us'
@@ -82,7 +84,8 @@ export interface UseContentInterface {
    * ```typescript
    * import { onMounted, ref } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
-   * export function {
+   *
+   * export default {
    *   setup() {
    *     const { loadPage } = useContent();
    *     const page = ref({});
@@ -112,7 +115,7 @@ export interface UseContentInterface {
    * import { useFetch, ref } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
    *
-   * export function {
+   * export default {
    *   setup(props) {
    *     const { loadBlocks } = useContent();
    *     const blocks = ref([]);
@@ -132,7 +135,7 @@ export interface UseContentInterface {
    * import { useAsync } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
    *
-   * export function {
+   * export default {
    *   setup(props) {
    *     const { loadBlocks } = useContent();
    *
@@ -153,7 +156,7 @@ export interface UseContentInterface {
    * import { onMounted, ref } from '@nuxtjs/composition-api';
    * import { useContent } from '~/composables';
    *
-   * export function {
+   * export default {
    *   setup(props) {
    *     const { loadBlocks } = useContent();
    *     const blocks = ref([]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The JSDoc examples of the `useContent` composable were using `export function {` instead of `export default {`, probably just a typo. I've fixed that and added space between import statements and the export in some examples.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
`export function {` is a syntax error.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
