### PR TITLE
fix: vsf cloud has no redis on localhost

### DIFF
--- a/.github/workflows/deploy-vue-storefront-cloud.yml
+++ b/.github/workflows/deploy-vue-storefront-cloud.yml
@@ -46,7 +46,7 @@ jobs:
           VSF_IMAGE_PROVIDER_BASE_URL: https://res-4.cloudinary.com/dnozky7on/image/upload/
 
           VSF_REDIS_ENABLED: true
-          VSF_REDIS_HOST: localhost
+          VSF_REDIS_HOST: redis # VSF cloud specific
           VSF_REDIS_PORT: 6379
           VSF_REDIS_KEY_PREFIX: ${{ github.sha }}
           VSF_REDIS_CACHE_INVALIDATE_KEY: magento2vsf2


### PR DESCRIPTION
After removal of secrets there's a problem where the theme is trying to find redis on the localhost host, but redis in VSF cloud is actually on the `redis` host