### PR TITLE
chore: removed cache-control settings from product and category page

### DIFF
--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -260,10 +260,6 @@ export default defineComponent({
     SfProperty,
     LazyHydrate,
   },
-  middleware: cacheControl({
-    'max-age': 60,
-    'stale-when-revalidate': 5,
-  }),
   transition: 'fade',
   setup() {
     const { getContentData } = useCategoryContent();

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -340,10 +340,6 @@ export default defineComponent({
     SvgImage,
     UpsellProducts,
   },
-  middleware: cacheControl({
-    'max-age': 60,
-    'stale-when-revalidate': 5,
-  }),
   transition: 'fade',
   setup() {
     const { addTags } = useCache();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We have not supported CDN for pages yet so for now we can remove cache-control settings.

