### PR TITLE
fix: image provider options

### DIFF
--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -26,7 +26,7 @@ module.exports = {
         },
         magentoBaseUrl: process.env.VSF_MAGENTO_BASE_URL,
         magentoApiEndpoint: process.env.VSF_MAGENTO_GRAPHQL_URL,
-        imageProvider: process.env.VSF_IMAGAE_PROVIDER,
+        imageProvider: process.env.VSF_IMAGE_PROVIDER,
         recaptcha: {
           isEnabled: process.env.VSF_RECAPTCHA_ENABLED === 'true',
           sitekey: process.env.VSF_RECAPTCHA_SITE_KEY,


### PR DESCRIPTION
## Description
- add imageProvider option value to the magento module

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
bugfix

## How Has This Been Tested?
manipulate VSF_IMAGE_PROVIDER env variable and observe if images are loaded properly for [ipx, cloudinary] at least

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
