### PR TITLE
refactor: removed size guide

### DIFF
--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -156,7 +156,6 @@ export default {
   "Show on page": "Auf Seite anzeigen",
   "Sign in": "Einloggen",
   "Sign Up for Newsletter": "Anmeldung für Newsletter",
-  "Size guide": "Größentabelle",
   "Sort by": "Sortieren nach",
   "Sort: Default": "Standard",
   "Sort: Name A-Z": "Benennen Sie A-Z",

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -151,7 +151,6 @@ export default {
   "Show on page": "Show on page",
   "Sign in": "Sign in",
   "Sign Up for Newsletter": "Sign Up for Newsletter",
-  "Size guide": "Size guide",
   "Sort by": "Sort by",
   "Sort: Default": "Default",
   "Sort: Name A-Z": "Name A-Z",

--- a/packages/theme/pages/Product.vue
+++ b/packages/theme/pages/Product.vue
@@ -81,9 +81,6 @@
                 tag="p"
                 class="product__description desktop-only"
               />
-              <SfButton class="sf-button--text desktop-only product__guide">
-                {{ $t('Size guide') }}
-              </SfButton>
               <template v-for="option in configurableOptions">
                 <div
                   v-if="option.attribute_code === 'color'"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
There was a "size guide" button on PDP. But we won't support the size guide (whatever it means) on the 1.0.0 page so I removed that button and translations from the code base.


## Screenshots (if appropriate):
### Before
![Screenshot 2022-04-12 at 14 11 43](https://user-images.githubusercontent.com/11998249/162959826-ee40c7a5-8711-4f09-a5f8-1ba3460d3364.png)

### After
![Screenshot 2022-04-12 at 14 12 34](https://user-images.githubusercontent.com/11998249/162959963-f50c7a95-60c8-43b3-af1b-fb5714e3b243.png)

