### PR TITLE
feat!: define a type for billingDetails and make refs readonly in the useBilling composable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -93,6 +93,7 @@ module.exports = {
         title: 'Composables',
         children: [
           ['/api-reference/magento-theme.useaddresses', 'useAddresses()'],
+          ['/api-reference/magento-theme.usebilling', 'useBilling()'],
           ['/api-reference/magento-theme.usecontent', 'useContent()'],
           ['/api-reference/magento-theme.usecategory', 'useCategory()'],
         ]

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -27,7 +27,7 @@ export { default as useProduct } from './useProduct';
 export { default as useReview } from './useReview';
 export { default as useShipping } from './useShipping';
 export { default as useShippingProvider } from './useShippingProvider';
-export { default as useBilling } from './useBilling';
+export * from './useBilling';
 export { default as useRelatedProducts } from './useRelatedProducts';
 export { default as useUpsellProducts } from './useUpsellProducts';
 export { default as usePaymentProvider } from './usePaymentProvider';

--- a/packages/theme/composables/useBilling/BillingDetails.ts
+++ b/packages/theme/composables/useBilling/BillingDetails.ts
@@ -1,0 +1,18 @@
+/** The object used by {@link useBilling} to save new billing information. */
+interface BillingDetails {
+  apartment?: string;
+  city?: string;
+  country_code?: string;
+  customerAddressId: string;
+  extra?: string;
+  firstname?: string;
+  lastname?: string;
+  neighborhood?: string;
+  postcode?: string;
+  region?: string;
+  sameAsShipping: boolean;
+  street?: string;
+  telephone?: string;
+}
+
+export default BillingDetails;

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -10,6 +10,19 @@ import type {
   UseBillingSaveParams,
 } from './useBilling';
 
+/**
+ * The `useBilling()` composable allows loading and saving billing information
+ * of the current cart.
+ *
+ * @remarks
+ * The `useBilling()` composable allows:
+ *
+ * - Fetch existing billing information;
+ *
+ * - Save new billing information;
+ *
+ * - Modify existing billing information;
+ */
 export function useBilling(): UseBillingInterface {
   const context = useContext();
   const { load: loadShippingAddress, save: saveShippingAddress } = useShippingProvider();

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -3,19 +3,25 @@ import { Logger } from '~/helpers/logger';
 import { BillingCartAddress, Maybe } from '~/modules/GraphQL/types';
 import { saveBillingAddressCommand } from '~/composables/useBilling/commands/saveBillingAddressCommand';
 import { useShippingProvider, useCart } from '~/composables';
+import type {
+  UseBillingError,
+  UseBillingInterface,
+  UseBillingLoadParams,
+  UseBillingSaveParams,
+} from './useBilling';
 
-export function useBilling() {
+export function useBilling(): UseBillingInterface {
   const context = useContext();
   const { load: loadShippingAddress, save: saveShippingAddress } = useShippingProvider();
   const { cart, load: loadCart } = useCart();
 
   const loading = ref(false);
-  const error = ref({
+  const error = ref<UseBillingError>({
     load: null,
     save: null,
   });
 
-  const load = async ({ customQuery = null } = {}): Promise<Maybe<BillingCartAddress>> => {
+  const load = async ({ customQuery = null }: UseBillingLoadParams = {}): Promise<Maybe<BillingCartAddress>> => {
     Logger.debug('useBilling.load');
     let billingInfo = null;
 
@@ -37,7 +43,7 @@ export function useBilling() {
     return billingInfo;
   };
 
-  const save = async ({ billingDetails }): Promise<Maybe<BillingCartAddress>> => {
+  const save = async ({ billingDetails }: UseBillingSaveParams): Promise<Maybe<BillingCartAddress>> => {
     Logger.debug('useBilling.save');
     let billingInfo = null;
 
@@ -80,5 +86,7 @@ export function useBilling() {
     save,
   };
 }
+
+export * from './useBilling';
 
 export default useBilling;

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api';
+import { readonly, ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import { BillingCartAddress, Maybe } from '~/modules/GraphQL/types';
 import { saveBillingAddressCommand } from '~/composables/useBilling/commands/saveBillingAddressCommand';
@@ -93,10 +93,10 @@ export function useBilling(): UseBillingInterface {
   };
 
   return {
-    loading,
-    error,
     load,
     save,
+    error: readonly(error),
+    loading: readonly(loading),
   };
 }
 

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -13,15 +13,6 @@ import type {
 /**
  * The `useBilling()` composable allows loading and saving billing information
  * of the current cart.
- *
- * @remarks
- * The `useBilling()` composable allows:
- *
- * - Fetch existing billing information;
- *
- * - Save new billing information;
- *
- * - Modify existing billing information;
  */
 export function useBilling(): UseBillingInterface {
   const context = useContext();

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -4,7 +4,7 @@ import { BillingCartAddress, Maybe } from '~/modules/GraphQL/types';
 import { saveBillingAddressCommand } from '~/composables/useBilling/commands/saveBillingAddressCommand';
 import { useShippingProvider, useCart } from '~/composables';
 
-export const useBilling = () => {
+export function useBilling() {
   const context = useContext();
   const { load: loadShippingAddress, save: saveShippingAddress } = useShippingProvider();
   const { cart, load: loadCart } = useCart();
@@ -62,7 +62,6 @@ export const useBilling = () => {
       /**
        * End of GraphQL Workaround
        */
-
       error.value.save = null;
     } catch (err) {
       error.value.save = err;
@@ -80,6 +79,6 @@ export const useBilling = () => {
     load,
     save,
   };
-};
+}
 
 export default useBilling;

--- a/packages/theme/composables/useBilling/index.ts
+++ b/packages/theme/composables/useBilling/index.ts
@@ -101,5 +101,5 @@ export function useBilling(): UseBillingInterface {
 }
 
 export * from './useBilling';
-
+export { default as BillingDetails } from './BillingDetails';
 export default useBilling;

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -29,7 +29,7 @@ export interface UseBillingInterface {
    * Loads the billing information. It returns a `Promise` that resolves into
    * the billing information, or `null` when fails or is empty.
    */
-  load(params: UseBillingLoadParams): Promise<BillingCartAddress | null>;
+  load(params?: UseBillingLoadParams): Promise<BillingCartAddress | null>;
 
   /**
    * Saves the billing information. It, also, returns a `Promise` that resolves

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -1,4 +1,4 @@
-import type { Ref } from '@nuxtjs/composition-api';
+import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import type { BillingCartAddress } from '~/modules/GraphQL/types';
 import { ComposableFunctionArgs } from '~/types/core';
 
@@ -37,8 +37,8 @@ export interface UseBillingInterface {
   save(params: UseBillingSaveParams): Promise<BillingCartAddress | null>;
 
   /** Contains errors from any of the composable methods. */
-  error: Ref<UseBillingError>;
+  error: DeepReadonly<Ref<UseBillingError>>;
 
   /** Indicates whether any of the methods above is in progress. */
-  loading: Ref<boolean>;
+  loading: Readonly<Ref<boolean>>;
 }

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -1,0 +1,21 @@
+import type { Ref } from '@nuxtjs/composition-api';
+import type { BillingCartAddress } from '~/modules/GraphQL/types';
+import { ComposableFunctionArgs } from '~/types/core';
+
+export interface UseBillingError {
+  load: Error | null;
+  save: Error | null;
+}
+
+export type UseBillingLoadParams = ComposableFunctionArgs<{}>;
+
+export interface UseBillingSaveParams {
+  billingDetails: any;
+}
+
+export interface UseBillingInterface {
+  error: Ref<UseBillingError>;
+  loading: Ref<boolean>;
+  load(params: UseBillingLoadParams): Promise<BillingCartAddress | null>;
+  save(params: UseBillingSaveParams): Promise<BillingCartAddress | null>;
+}

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -2,20 +2,43 @@ import type { Ref } from '@nuxtjs/composition-api';
 import type { BillingCartAddress } from '~/modules/GraphQL/types';
 import { ComposableFunctionArgs } from '~/types/core';
 
+/**
+ * The {@link useBilling} error object. The properties values' are the errors
+ * thrown by its methods.
+ */
 export interface UseBillingError {
+  /** Error when loading the billing information fails, otherwise is `null`. */
   load: Error | null;
+
+  /** Error when saving the billing information fails, otherwise is `null`. */
   save: Error | null;
 }
 
+/** The params received by {@link useBilling}'s `load` method. */
 export type UseBillingLoadParams = ComposableFunctionArgs<{}>;
 
+/** The params received by {@link useBilling}'s `save` method. */
 export interface UseBillingSaveParams {
   billingDetails: any;
 }
 
+/** The interface provided by {@link useBilling} composable. */
 export interface UseBillingInterface {
-  error: Ref<UseBillingError>;
-  loading: Ref<boolean>;
+  /**
+   * Loads the billing information. It returns a `Promise` that resolves into
+   * the billing information, or `null` when fails or is empty.
+   */
   load(params: UseBillingLoadParams): Promise<BillingCartAddress | null>;
+
+  /**
+   * Saves the billing information. It, also, returns a `Promise` that resolves
+   * into the saved billing information, or `null` when fails.
+   */
   save(params: UseBillingSaveParams): Promise<BillingCartAddress | null>;
+
+  /** Contains errors from any of the composable methods. */
+  error: Ref<UseBillingError>;
+
+  /** Indicates whether any of the methods above is in progress. */
+  loading: Ref<boolean>;
 }

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -40,6 +40,6 @@ export interface UseBillingInterface {
   /** Contains errors from any of the composable methods. */
   error: DeepReadonly<Ref<UseBillingError>>;
 
-  /** Indicates whether any of the methods above is in progress. */
+  /** Indicates whether any of the methods is in progress. */
   loading: Readonly<Ref<boolean>>;
 }

--- a/packages/theme/composables/useBilling/useBilling.ts
+++ b/packages/theme/composables/useBilling/useBilling.ts
@@ -1,6 +1,7 @@
 import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import type { BillingCartAddress } from '~/modules/GraphQL/types';
 import { ComposableFunctionArgs } from '~/types/core';
+import type BillingDetails from './BillingDetails';
 
 /**
  * The {@link useBilling} error object. The properties values' are the errors
@@ -19,7 +20,7 @@ export type UseBillingLoadParams = ComposableFunctionArgs<{}>;
 
 /** The params received by {@link useBilling}'s `save` method. */
 export interface UseBillingSaveParams {
-  billingDetails: any;
+  billingDetails: BillingDetails;
 }
 
 /** The interface provided by {@link useBilling} composable. */


### PR DESCRIPTION
## Description
- **[BREAKING CHANGE]** Make the `loading` and `error` ref readonly;
- **[BREAKING CHANGE]** Define a type for the `billingDetails` object received by the `save` method;
- Add types and interfaces for the `useBilling` composable;
- Write TSDoc comments for `useBilling` and its types;
- Change `useBilling` to function declaration (since it's better for the docs generator).

## Related Issue
https://vsf.atlassian.net/browse/M2-374

## Motivation and Context
Improves the DX of the `useBilling` composable.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
