### PR TITLE
feat!: make `error`, `loading`, and `result` properties readonly on `useCategorySearch` composable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -95,6 +95,7 @@ module.exports = {
           ['/api-reference/magento-theme.useaddresses', 'useAddresses()'],
           ['/api-reference/magento-theme.usecontent', 'useContent()'],
           ['/api-reference/magento-theme.usecategory', 'useCategory()'],
+          ['/api-reference/magento-theme.usecategorysearch', 'useCategorySearch()'],
         ]
       },
       {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -103,6 +103,7 @@ module.exports = {
           ['/api-reference/magento-api.cmsblocks', 'cmsBlocks'],
           ['/api-reference/magento-api.cmspage', 'cmsPage'],
           ['/api-reference/magento-api.categorylist', 'categoryList'],
+          ['/api-reference/magento-api.categorysearch', 'categorySearch'],
           ['/api-reference/magento-api.createcustomeraddress', 'createCustomerAddress'],
           ['/api-reference/magento-api.deletecustomeraddress', 'deleteCustomerAddress'],
           ['/api-reference/magento-api.getcustomeraddresses', 'getCustomerAddresses'],

--- a/packages/api-client/src/api/categorySearch/categorySearch.ts
+++ b/packages/api-client/src/api/categorySearch/categorySearch.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 
+/** GraphQL Query that searches for categories using filters. */
 export default gql`
   query categorySearch($filters: CategoryFilterInput) {
     categoryList(filters: $filters) {

--- a/packages/api-client/src/api/categorySearch/index.ts
+++ b/packages/api-client/src/api/categorySearch/index.ts
@@ -1,26 +1,23 @@
 import { ApolloQueryResult } from '@apollo/client/core';
 import { CustomQuery } from '@vue-storefront/core';
 import { CategorySearchQuery, CategorySearchQueryVariables } from '../../types/GraphQL';
-import categorySearch from './categorySearch';
+import categorySearchQuery from './categorySearch';
 import { Context } from '../../types/context';
 
-export default async (
+export default async function categorySearch(
   context: Context,
   filters: CategorySearchQueryVariables,
   customQuery: CustomQuery = { categorySearch: 'categorySearch' },
-): Promise<ApolloQueryResult<CategorySearchQuery>> => {
-  const { categorySearch: categorySearchGQL } = context.extendQuery(
-    customQuery,
-    {
-      categorySearch: {
-        query: categorySearch,
-        variables: { ...filters },
-      },
+): Promise<ApolloQueryResult<CategorySearchQuery>> {
+  const { categorySearch: categorySearchGQL } = context.extendQuery(customQuery, {
+    categorySearch: {
+      query: categorySearchQuery,
+      variables: { ...filters },
     },
-  );
+  });
 
   return context.client.query<CategorySearchQuery, CategorySearchQueryVariables>({
     query: categorySearchGQL.query,
     variables: categorySearchGQL.variables,
   });
-};
+}

--- a/packages/api-client/src/api/categorySearch/index.ts
+++ b/packages/api-client/src/api/categorySearch/index.ts
@@ -4,6 +4,15 @@ import { CategorySearchQuery, CategorySearchQueryVariables } from '../../types/G
 import categorySearchQuery from './categorySearch';
 import { Context } from '../../types/context';
 
+/**
+ * Searches for categories using received filters.
+ *
+ * @param context VSF Context
+ * @param filters filters used to search for categories. A filter contains at
+ * least one attribute, a comparison operator, and the value that is being
+ * searched for.
+ * @param [customQuery] (optional) - custom GraphQL query that extends the default query
+ */
 export default async function categorySearch(
   context: Context,
   filters: CategorySearchQueryVariables,

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -22,7 +22,7 @@ export * from './useCategory';
 export { default as useFacet } from './useFacet';
 export { default as useCart } from './useCart';
 export * from './useContent';
-export { default as useCategorySearch } from './useCategorySearch';
+export * from './useCategorySearch';
 export { default as useProduct } from './useProduct';
 export { default as useReview } from './useReview';
 export { default as useShipping } from './useShipping';

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api';
+import { readonly, ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import type { Category } from '~/composables/types';
@@ -33,9 +33,9 @@ export function useCategorySearch(): UseCategorySearchInterface {
 
   return {
     search,
-    loading,
-    error,
-    result,
+    loading: readonly(loading),
+    error: readonly(error),
+    result: readonly(result),
   };
 }
 

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -4,7 +4,10 @@ import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import type { Category } from '~/composables/types';
 import type { UseCategoryErrors, UseCategorySearchInterface } from './useCategorySearch';
 
-/** The `useCategorySearch()` composable allows searching for categories. */
+/**
+ * The `useCategorySearch()` composable allows searching for categories. It is
+ * commonly used in subtrees navigation.
+ */
 export function useCategorySearch(): UseCategorySearchInterface {
   const { app } = useContext();
   const loading = ref(false);

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -4,6 +4,7 @@ import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import type { Category } from '~/composables/types';
 import type { UseCategoryErrors, UseCategorySearchInterface } from './useCategorySearch';
 
+/** The `useCategorySearch()` composable allows searching for categories. */
 export function useCategorySearch(): UseCategorySearchInterface {
   const { app } = useContext();
   const loading = ref(false);

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -1,19 +1,17 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { ref, Ref, useContext } from '@nuxtjs/composition-api';
+import { ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
-import { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
-import { UseCategoryErrors, UseCategorySearchInterface } from '~/composables/useCategorySearch/useCategorySearch';
-import { Category } from '~/composables/types';
+import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
+import type { Category } from '~/composables/types';
+import type { UseCategoryErrors, UseCategorySearchInterface } from './useCategorySearch';
 
 export function useCategorySearch(): UseCategorySearchInterface {
   const { app } = useContext();
-  const loading: Ref<boolean> = ref(false);
-  const error: Ref<UseCategoryErrors> = ref({
+  const loading = ref(false);
+  const error = ref<UseCategoryErrors>({
     search: null,
   });
-  const result: Ref<Array<Category>> = ref(null);
+  const result = ref<Category[] | null>(null);
 
-  // eslint-disable-next-line consistent-return
   const search = async (searchParams: CategorySearchQueryVariables) => {
     Logger.debug('useCategory/search', searchParams);
 
@@ -40,4 +38,5 @@ export function useCategorySearch(): UseCategorySearchInterface {
   };
 }
 
+export * from './useCategorySearch';
 export default useCategorySearch;

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -5,7 +5,7 @@ import { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import { UseCategoryErrors, UseCategorySearchInterface } from '~/composables/useCategorySearch/useCategorySearch';
 import { Category } from '~/composables/types';
 
-export const useCategorySearch = (): UseCategorySearchInterface => {
+export function useCategorySearch(): UseCategorySearchInterface {
   const { app } = useContext();
   const loading: Ref<boolean> = ref(false);
   const error: Ref<UseCategoryErrors> = ref({
@@ -38,6 +38,6 @@ export const useCategorySearch = (): UseCategorySearchInterface => {
     error,
     result,
   };
-};
+}
 
 export default useCategorySearch;

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -2,10 +2,10 @@
 import { ref, Ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
-import { UseCategoryErrors, UseCategorySearch } from '~/composables/useCategorySearch/useCategorySearch';
+import { UseCategoryErrors, UseCategorySearchInterface } from '~/composables/useCategorySearch/useCategorySearch';
 import { Category } from '~/composables/types';
 
-export const useCategorySearch = (): UseCategorySearch => {
+export const useCategorySearch = (): UseCategorySearchInterface => {
   const { app } = useContext();
   const loading: Ref<boolean> = ref(false);
   const error: Ref<UseCategoryErrors> = ref({

--- a/packages/theme/composables/useCategorySearch/index.ts
+++ b/packages/theme/composables/useCategorySearch/index.ts
@@ -2,7 +2,7 @@ import { readonly, ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import type { Category } from '~/composables/types';
-import type { UseCategoryErrors, UseCategorySearchInterface } from './useCategorySearch';
+import type { UseCategorySearchErrors, UseCategorySearchInterface } from './useCategorySearch';
 
 /**
  * The `useCategorySearch()` composable allows searching for categories. It is
@@ -11,7 +11,7 @@ import type { UseCategoryErrors, UseCategorySearchInterface } from './useCategor
 export function useCategorySearch(): UseCategorySearchInterface {
   const { app } = useContext();
   const loading = ref(false);
-  const error = ref<UseCategoryErrors>({
+  const error = ref<UseCategorySearchErrors>({
     search: null,
   });
   const result = ref<Category[] | null>(null);

--- a/packages/theme/composables/useCategorySearch/useCategorySearch.ts
+++ b/packages/theme/composables/useCategorySearch/useCategorySearch.ts
@@ -1,14 +1,23 @@
-import { Ref } from '@nuxtjs/composition-api';
-import { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
-import { Category, ComposableFunctionArgs } from '~/composables/types';
+import type { Ref } from '@nuxtjs/composition-api';
+import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
+import type { Category, ComposableFunctionArgs } from '~/composables/types';
 
+/**
+ * The {@link useCategorySearch} error object. The properties values' are the
+ * errors thrown by its methods.
+ */
 export interface UseCategoryErrors {
-  search: Error;
+  /** Error when searching for categories fails, otherwise is `null`. */
+  search: Error | null;
 }
 
+/** The params received by {@link useCategorySearch}'s `search` method. */
+export type UseCategorySearchParams = ComposableFunctionArgs<CategorySearchQueryVariables>;
+
+/** The interface provided by {@link useCategorySearch} composable. */
 export interface UseCategorySearchInterface {
-  result: Ref<Array<Category>>,
-  search(searchParams: ComposableFunctionArgs<CategorySearchQueryVariables>): Promise<void>;
-  loading: Ref<boolean>;
   error: Ref<UseCategoryErrors>;
+  result: Ref<Category[]>;
+  loading: Ref<boolean>;
+  search(searchParams: UseCategorySearchParams): Promise<void>;
 }

--- a/packages/theme/composables/useCategorySearch/useCategorySearch.ts
+++ b/packages/theme/composables/useCategorySearch/useCategorySearch.ts
@@ -6,7 +6,7 @@ import type { Category, ComposableFunctionArgs } from '~/composables/types';
  * The {@link useCategorySearch} error object. The properties values' are the
  * errors thrown by its methods.
  */
-export interface UseCategoryErrors {
+export interface UseCategorySearchErrors {
   /** Error when searching for categories fails, otherwise is `null`. */
   search: Error | null;
 }
@@ -23,7 +23,7 @@ export interface UseCategorySearchInterface {
   search(searchParams: UseCategorySearchParams): Promise<void>;
 
   /** Contains errors from any of the composable methods. */
-  error: DeepReadonly<Ref<UseCategoryErrors>>;
+  error: DeepReadonly<Ref<UseCategorySearchErrors>>;
 
   /**
    * The list of {@link Category} found by the last search. It's `null` if the

--- a/packages/theme/composables/useCategorySearch/useCategorySearch.ts
+++ b/packages/theme/composables/useCategorySearch/useCategorySearch.ts
@@ -1,4 +1,4 @@
-import type { Ref } from '@nuxtjs/composition-api';
+import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import type { CategorySearchQueryVariables } from '~/modules/GraphQL/types';
 import type { Category, ComposableFunctionArgs } from '~/composables/types';
 
@@ -23,14 +23,14 @@ export interface UseCategorySearchInterface {
   search(searchParams: UseCategorySearchParams): Promise<void>;
 
   /** Contains errors from any of the composable methods. */
-  error: Ref<UseCategoryErrors>;
+  error: DeepReadonly<Ref<UseCategoryErrors>>;
 
   /**
    * The list of {@link Category} found by the last search. It's `null` if the
    * search has not been executed yet or fails.
    */
-  result: Ref<Category[] | null>;
+  result: DeepReadonly<Ref<Category[] | null>>;
 
   /** Indicates whether any of the composable methods is in progress. */
-  loading: Ref<boolean>;
+  loading: Readonly<Ref<boolean>>;
 }

--- a/packages/theme/composables/useCategorySearch/useCategorySearch.ts
+++ b/packages/theme/composables/useCategorySearch/useCategorySearch.ts
@@ -6,7 +6,7 @@ export interface UseCategoryErrors {
   search: Error;
 }
 
-export interface UseCategorySearch{
+export interface UseCategorySearchInterface {
   result: Ref<Array<Category>>,
   search(searchParams: ComposableFunctionArgs<CategorySearchQueryVariables>): Promise<void>;
   loading: Ref<boolean>;

--- a/packages/theme/composables/useCategorySearch/useCategorySearch.ts
+++ b/packages/theme/composables/useCategorySearch/useCategorySearch.ts
@@ -16,8 +16,21 @@ export type UseCategorySearchParams = ComposableFunctionArgs<CategorySearchQuery
 
 /** The interface provided by {@link useCategorySearch} composable. */
 export interface UseCategorySearchInterface {
-  error: Ref<UseCategoryErrors>;
-  result: Ref<Category[]>;
-  loading: Ref<boolean>;
+  /**
+   * Searches for categories using the received filters and updates the
+   * {@link UseCategorySearchInterface.result} ref with the results.
+   */
   search(searchParams: UseCategorySearchParams): Promise<void>;
+
+  /** Contains errors from any of the composable methods. */
+  error: Ref<UseCategoryErrors>;
+
+  /**
+   * The list of {@link Category} found by the last search. It's `null` if the
+   * search has not been executed yet or fails.
+   */
+  result: Ref<Category[] | null>;
+
+  /** Indicates whether any of the composable methods is in progress. */
+  loading: Ref<boolean>;
 }


### PR DESCRIPTION
## Description
- **[BREAKING CHANGE]** Make the `error`, `loading` and `result` refs readonly;
- **[BREAKING CHANGE]** Rename `UseCategorySearch` interface to `UseCategorySearchInterface`;
- **[BREAKING CHANGE]** Rename `UseCategoryErrors` interface to `UseCategorySearchErrors`;
- Add type for the params object received by `UseCategorySearch.search` method;
- Write TSDocs for `categorySearch` API method and its GraphQL query;
- Write TSDocs for `useCategorySearch` composable and its types;
- Convert `useCategorySearch` and `categorySearch` into function declarations (since it's better for the docs generator);
- Export `useCategorySearch` types in `~/composables`.

## Related Issue
https://vsf.atlassian.net/browse/M2-374

## Motivation and Context
Improves the DX of the `useCategorySearch` composable.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
