### PR TITLE
refactor: remove category getters call from app header

### DIFF
--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -183,17 +183,13 @@ export default defineComponent({
     useFetch(async () => {
       await categoriesListLoad({ pageSize: 20 });
 
-      function prepareMenuData() {
-        return categoryList.value?.[0]?.children
-          .map((category) => ({
-            includeInMenu: category.include_in_menu,
-            label: category.name,
-            slug: `/${category.url_path}${category.url_suffix}`,
-          }))
-          .filter((category) => category.includeInMenu) ?? [];
-      }
-
-      categoryTree.value = prepareMenuData();
+      categoryTree.value = categoryList.value?.[0]?.children
+        .filter((category) => category.include_in_menu)
+        .map((category) => ({
+          includeInMenu: category.include_in_menu,
+          label: category.name,
+          slug: `/${category.url_path}${category.url_suffix}`,
+        })) ?? [];
     });
 
     onMounted(() => {

--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -108,7 +108,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import {
   SfOverlay, SfHeader, SfButton, SfBadge,
 } from '@storefront-ui/vue';
@@ -122,7 +122,6 @@ import {
   onMounted,
   useFetch,
 } from '@nuxtjs/composition-api';
-import { categoryGetters } from '~/getters';
 import HeaderNavigationItem from '~/components/Header/Navigation/HeaderNavigationItem.vue';
 import {
   useCart,
@@ -183,16 +182,25 @@ export default defineComponent({
 
     useFetch(async () => {
       await categoriesListLoad({ pageSize: 20 });
-      categoryTree.value = categoryGetters
-        .getCategoryTree(categoryList.value?.[0])
-        ?.items.filter((c) => c.count > 0);
+
+      function prepareMenuData() {
+        return categoryList.value?.[0]?.children
+          .map((category) => ({
+            includeInMenu: category.include_in_menu,
+            label: category.name,
+            slug: `/${category.url_path}${category.url_suffix}`,
+          }))
+          .filter((category) => category.includeInMenu) ?? [];
+      }
+
+      categoryTree.value = prepareMenuData();
     });
 
     onMounted(() => {
       if (app.$device.isDesktop) {
         loadCartTotalQty();
         // eslint-disable-next-line promise/catch-or-return
-        loadWishlistItemsCount()
+        loadWishlistItemsCount({})
           .then((response) => {
             wishlistItemsQty.value = response;
 

--- a/packages/theme/composables/types.ts
+++ b/packages/theme/composables/types.ts
@@ -87,7 +87,7 @@ export declare type GetProductSearchParams = {
 export declare type AvailableStores = AvailableStoresQuery['availableStores'];
 export declare type CartItem = CartItemInterface;
 export declare type CustomQuery = Record<string, string>;
-export declare type Category = CategoryTree | CategorySearchQuery['categoryList'][0];
+export declare type Category = CategoryTree;
 export interface Product extends ProductInterface, ConfigurableProduct, Omit<BundleProduct, 'items'>, Omit<GroupedProduct, 'items'>, Omit<DownloadableProduct, 'items'>, Omit<VirtualProduct, 'items'> { __typename: string }
 export declare type Filter = Record<string, any>;
 export declare type Countries = CountriesListQuery['countries'][0];

--- a/packages/theme/composables/useCart/useCart.ts
+++ b/packages/theme/composables/useCart/useCart.ts
@@ -1,4 +1,3 @@
-import { Context } from '@nuxt/types';
 import { ComputedRef, DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import { ComposableFunctionArgs } from '~/composables/types';
 
@@ -55,7 +54,7 @@ export interface UseCartInterface<CART, CART_ITEM, PRODUCT> {
   /** Loads the current cart */
   load(params: ComposableFunctionArgs<{ realCart?: boolean }>): Promise<void>;
   /** Updates the global application state with the current total quantity of the cart */
-  loadTotalQty(context: Context['app']): Promise<void>;
+  loadTotalQty(): Promise<void>;
   /** Takes in a `product` and its `quantity` and adds it to the cart */
   addItem(
     params: UseCartAddItemParams<PRODUCT>

--- a/packages/theme/getters/productGetters.ts
+++ b/packages/theme/getters/productGetters.ts
@@ -7,14 +7,14 @@ import {
   Product,
 } from '~/composables/types';
 import { ProductGetters as ProductGettersBase } from '~/getters/types';
-import { BundleProduct, GroupedProduct } from '~/modules/GraphQL/types';
+import {
+  BundleProduct, CategoryInterface, GroupedProduct, ProductInterface,
+} from '~/modules/GraphQL/types';
 import { htmlDecode } from '~/helpers/htmlDecoder';
 import categoryGetters from './categoryGetters';
 import reviewGetters from './reviewGetters';
 
-type ProductVariantFilters = any;
-
-export const getName = (product: Product): string => {
+export const getName = (product: ProductInterface): string => {
   if (!product) {
     return '';
   }
@@ -22,7 +22,7 @@ export const getName = (product: Product): string => {
   return htmlDecode(product.name);
 };
 
-export const getSlug = (product: Product, category?: Category): string => {
+export const getSlug = (product: ProductInterface, category?: Category): string => {
   const rewrites = product?.url_rewrites;
   let url = product?.sku ? `/p/${product.sku}` : '';
   if (!rewrites || rewrites.length === 0) {
@@ -97,14 +97,6 @@ export const getProductThumbnailImage = (product: Product): string => {
   }
 
   return product.thumbnail.url;
-};
-
-export const getFiltered = (products: Product[], filters: ProductVariantFilters | any = {}): Product[] => {
-  if (!products) {
-    return [];
-  }
-
-  return products;
 };
 
 export const getAttributes = (
@@ -207,7 +199,7 @@ export const getFormattedPrice = (price: number) => {
   }).format(price);
 };
 
-export const getBreadcrumbs = (product: any, category?: Category): AgnosticBreadcrumb[] => {
+export const getBreadcrumbs = (product: ProductInterface, category?: Category): AgnosticBreadcrumb[] => {
   let breadcrumbs = [];
 
   if (!product) {
@@ -244,14 +236,14 @@ export const getGroupedProducts = (product: GroupedProduct & { __typename: strin
 // eslint-disable-next-line no-underscore-dangle
 export const getBundleProducts = (product: BundleProduct & { __typename: string }): BundleProduct['items'] | undefined => product.__typename === 'BundleProduct' && product?.items?.sort(sortProduct);
 
-export interface ProductGetters extends ProductGettersBase<Product, ProductVariantFilters> {
+export interface ProductGetters extends ProductGettersBase<Product> {
   getCategory(product: Product, currentUrlPath: string): Category | null;
   getProductRelatedProduct(product: Product): Product[];
   getProductSku(product: Product): string;
   getProductThumbnailImage(product: Product): string;
   getProductUpsellProduct(product: Product): Product[];
   getShortDescription(product: Product): string;
-  getSlug(product: Product, category?: Category): string;
+  getSlug(product: Product, category?: CategoryInterface): string;
   getTypeId(product: Product): string;
   getSwatchData(swatchData: Product['configurable_options'][0]['values'][0]['swatch_data']): string | undefined;
   getGroupedProducts(product: GroupedProduct): GroupedProduct['items'] | undefined;
@@ -266,7 +258,6 @@ const productGetters: ProductGetters = {
   getCategoryIds,
   getCoverImage,
   getDescription,
-  getFiltered,
   getFormattedPrice,
   getGallery,
   getId,

--- a/packages/theme/getters/types.d.ts
+++ b/packages/theme/getters/types.d.ts
@@ -19,13 +19,12 @@ export interface AddressGetter {
   }[];
 }
 
-export interface ProductGetters<PRODUCT, PRODUCT_FILTER> {
+export interface ProductGetters<PRODUCT> {
   getName: (product: PRODUCT) => string;
   getSlug: (product: PRODUCT) => string;
   getPrice: (product: PRODUCT) => AgnosticPrice;
   getGallery: (product: PRODUCT) => AgnosticMediaGalleryItem[];
   getCoverImage: (product: PRODUCT) => string;
-  getFiltered: (products: PRODUCT[], filters?: PRODUCT_FILTER) => PRODUCT[];
   getAttributes: (products: PRODUCT[] | PRODUCT, filters?: Array<string>) => Record<string, AgnosticAttribute | string>;
   getDescription: (product: PRODUCT) => string;
   getCategoryIds: (product: PRODUCT) => string[];

--- a/packages/theme/helpers/product/productData.ts
+++ b/packages/theme/helpers/product/productData.ts
@@ -1,21 +1,14 @@
 import { computed, useRoute } from '@nuxtjs/composition-api';
-import { productGetters } from '~/getters';
 
 export const productData = (products) => {
   const route = useRoute();
-  const { params: { id }, query } = route.value;
+  const { params: { id } } = route.value;
 
   return {
     id,
     product: computed(() => {
       if (!products) return {};
-      const baseProduct = Array.isArray(products.value?.items) && products.value?.items[0] ? products.value?.items[0] : [];
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      return productGetters.getFiltered(baseProduct, {
-        master: true,
-        attributes: query,
-      });
+      return Array.isArray(products.value?.items) && products.value?.items[0] ? products.value?.items[0] : [];
     }),
   };
 };

--- a/packages/theme/helpers/product/productData.ts
+++ b/packages/theme/helpers/product/productData.ts
@@ -8,7 +8,7 @@ export const productData = (products) => {
     id,
     product: computed(() => {
       if (!products) return {};
-      return Array.isArray(products.value?.items) && products.value?.items[0] ? products.value?.items[0] : [];
+      return products.value?.items?.[0] ?? [];
     }),
   };
 };

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -9,12 +9,14 @@
       class="breadcrumbs"
     />
     <CategoryNavbar
+      v-if="isShowProducts"
       :sort-by="sortBy"
       :pagination="pagination"
       @reloadProducts="fetch"
     />
     <div class="main section">
       <CategorySidebar
+        v-if="isShowProducts"
         class="sidebar desktop-only"
       />
       <div
@@ -316,7 +318,6 @@ export default defineComponent({
     const { fetch } = useFetch(async () => {
       routeData.value = await resolveUrl();
       const content = await getContentData(routeData.value?.id);
-
       cmsContent.value = content?.cmsBlock?.content ?? '';
       isShowCms.value = content.isShowCms;
       isShowProducts.value = content.isShowProducts;

--- a/packages/theme/pages/Home.vue
+++ b/packages/theme/pages/Home.vue
@@ -251,7 +251,7 @@ export default defineComponent({
 
       addTags([{ prefix: CacheTagPrefix.View, value: 'home' }]);
 
-      newProducts.value = productGetters.getFiltered(productsData?.items, { master: true });
+      newProducts.value = productsData?.items;
     });
 
     // @ts-ignore

--- a/packages/theme/pages/Home.vue
+++ b/packages/theme/pages/Home.vue
@@ -106,7 +106,6 @@ import {
 } from '@nuxtjs/composition-api';
 import LazyHydrate from 'vue-lazy-hydration';
 import { useCache, CacheTagPrefix } from '@vue-storefront/cache';
-import { productGetters } from '~/getters';
 import { useProduct } from '~/composables';
 import MobileStoreBanner from '~/components/MobileStoreBanner.vue';
 import InstagramFeed from '~/components/InstagramFeed.vue';
@@ -241,7 +240,7 @@ export default defineComponent({
     ]);
 
     onMounted(async () => {
-      const productsData = await getProductList({
+      newProducts.value = await getProductList({
         pageSize: 10,
         currentPage: 1,
         sort: {
@@ -250,8 +249,6 @@ export default defineComponent({
       });
 
       addTags([{ prefix: CacheTagPrefix.View, value: 'home' }]);
-
-      newProducts.value = productsData?.items;
     });
 
     // @ts-ignore
@@ -260,7 +257,6 @@ export default defineComponent({
       heroes,
       newProducts,
       newProductsLoading,
-      productGetters,
     };
   },
 });

--- a/packages/theme/types/core.d.ts
+++ b/packages/theme/types/core.d.ts
@@ -655,13 +655,12 @@ export interface AgnosticStore {
   [x: string]: unknown;
 }
 
-export interface ProductGetters<PRODUCT, PRODUCT_FILTER> {
+export interface ProductGetters<PRODUCT> {
   getName: (product: PRODUCT) => string;
   getSlug: (product: PRODUCT) => string;
   getPrice: (product: PRODUCT) => AgnosticPrice;
   getGallery: (product: PRODUCT) => AgnosticMediaGalleryItem[];
   getCoverImage: (product: PRODUCT) => string;
-  getFiltered: (products: PRODUCT[], filters?: PRODUCT_FILTER) => PRODUCT[];
   getAttributes: (products: PRODUCT[] | PRODUCT, filters?: Array<string>) => Record<string, AgnosticAttribute | string>;
   getDescription: (product: PRODUCT) => string;
   getCategoryIds: (product: PRODUCT) => string[];


### PR DESCRIPTION
## Description
We don’t use the category getters. Each value of the category object is used directly in the template. If we need some additional logic around some of the fields let’s encapsulate it in composable. 

## Related Issue
-

## Motivation and Context
Perf improvement

## How Has This Been Tested?
-

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
