### PR TITLE
refactor: refactored useCurrency `load` and `change` methods

### DIFF
--- a/packages/theme/composables/useCurrency/index.ts
+++ b/packages/theme/composables/useCurrency/index.ts
@@ -11,7 +11,7 @@ const useCurrency = (): UseCurrency => {
   const configStore = useConfigStore();
   const currency = computed(() => configStore.currency);
 
-  const load = async (params?: ComposableFunctionArgs<{ currency: string }>) => {
+  const load = async (params?: ComposableFunctionArgs<{}>) => {
     error.value.load = null;
     loading.value = true;
 

--- a/packages/theme/composables/useCurrency/index.ts
+++ b/packages/theme/composables/useCurrency/index.ts
@@ -32,8 +32,6 @@ const useCurrency = (): UseCurrency => {
 
   const change = (params: ComposableFunctionArgs<{ id: string }>) => {
     error.value.change = null;
-    loading.value = true;
-
     Logger.debug('useCurrency/change');
 
     try {
@@ -42,8 +40,6 @@ const useCurrency = (): UseCurrency => {
     } catch (err) {
       Logger.debug('[ERROR] useCurrency/change', err);
       error.value.change = err;
-    } finally {
-      loading.value = false;
     }
   };
 

--- a/packages/theme/composables/useCurrency/index.ts
+++ b/packages/theme/composables/useCurrency/index.ts
@@ -11,14 +11,14 @@ const useCurrency = (): UseCurrency => {
   const configStore = useConfigStore();
   const currency = computed(() => configStore.currency);
 
-  const load = async (params?: ComposableFunctionArgs<CustomQuery>) => {
+  const load = async (params?: ComposableFunctionArgs<{ currency: string }>) => {
     error.value.load = null;
     loading.value = true;
 
     Logger.debug('useCurrency/load');
 
     try {
-      const { data } = await app.$vsf.$magento.api.currency(params);
+      const { data } = await app.$vsf.$magento.api.currency(params?.customQuery ?? null);
       configStore.$patch((state) => {
         state.currency = data?.currency ?? {};
       });

--- a/packages/theme/composables/useCurrency/index.ts
+++ b/packages/theme/composables/useCurrency/index.ts
@@ -30,7 +30,7 @@ const useCurrency = (): UseCurrency => {
     }
   };
 
-  const change = (params: ComposableFunctionArgs<{ id: string }>) => {
+  const change = (params: { id: string }) => {
     error.value.change = null;
     Logger.debug('useCurrency/change');
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- The change method of useCurrency is synchronous so it's not necessary to set the loading state there.
- customQuery was not passed correctly to API, and it's fixed, params type also is fixed



