### PR TITLE
perf!: load whole user object only when necessary

### DIFF
--- a/packages/theme/composables/useCart/index.ts
+++ b/packages/theme/composables/useCart/index.ts
@@ -15,7 +15,7 @@ import { useCustomerStore } from '~/stores/customer';
 import { UseCartErrors, UseCartInterface } from './useCart';
 
 /**
- * The `useCart` composable provides functions and refs to deal with a usesr's cart from Magento API.
+ * The `useCart` composable provides functions and refs to deal with a user's cart from Magento API.
  *
  * See the {@link UseCartInterface} page for more information.
  */
@@ -38,7 +38,7 @@ PRODUCT
   const { app } = useContext();
   const context = app.$vsf;
   const customerStore = useCustomerStore();
-  const cart = computed<CART>(() => customerStore.cart);
+  const cart = computed(() => customerStore.cart as CART);
   const apiState = context.$magento.config.state;
 
   /**

--- a/packages/theme/composables/useUser/loginStatusPingQuery.gql.ts
+++ b/packages/theme/composables/useUser/loginStatusPingQuery.gql.ts
@@ -1,0 +1,15 @@
+import { gql } from 'graphql-request';
+
+/**
+ * Attempts querying the smallest amount of customer info to see if
+ * current user is logged in (has auth cookie and it's not expired)
+ *
+ * If not, sending this query will return graphql-authorization error
+ */
+export default gql`
+  query customer {
+    customer {
+      __typename
+    }
+  }
+`;

--- a/packages/theme/composables/useUser/useUser.ts
+++ b/packages/theme/composables/useUser/useUser.ts
@@ -23,7 +23,7 @@ export interface Customer {
 }
 
 export type UseUser = {
-  user: Ref<Customer>
+  user: Ref<Customer | null>
   loading: Ref<boolean>
   isAuthenticated: Ref<boolean>
   error: Ref<UseUserErrors>

--- a/packages/theme/layouts/default.vue
+++ b/packages/theme/layouts/default.vue
@@ -20,14 +20,12 @@
 </template>
 <script>
 import LazyHydrate from 'vue-lazy-hydration';
-import {
-  useRoute, defineComponent, useAsync,
-} from '@nuxtjs/composition-api';
-import { useUiState, useUser } from '~/composables';
-import LoadWhenVisible from '~/components/utils/LoadWhenVisible';
+import { useRoute, defineComponent } from '@nuxtjs/composition-api';
+import { useUiState } from '~/composables';
 import AppHeader from '~/components/AppHeader.vue';
 import BottomNavigation from '~/components/BottomNavigation.vue';
 import IconSprite from '~/components/General/IconSprite.vue';
+import LoadWhenVisible from '~/components/utils/LoadWhenVisible';
 import TopBar from '~/components/TopBar';
 
 export default defineComponent({
@@ -49,12 +47,7 @@ export default defineComponent({
 
   setup() {
     const route = useRoute();
-    const { load: loadUser } = useUser();
     const { isCartSidebarOpen, isWishlistSidebarOpen, isLoginModalOpen } = useUiState();
-
-    useAsync(async () => {
-      await loadUser();
-    });
 
     return {
       isCartSidebarOpen,

--- a/packages/theme/pages/Checkout/UserAccount.vue
+++ b/packages/theme/pages/Checkout/UserAccount.vue
@@ -280,7 +280,9 @@ export default defineComponent({
     };
 
     useFetch(async () => {
-      await load();
+      if(user.value === null) {
+        await load();
+      }
       if (isAuthenticated.value) {
         form.value.firstname = user.value.firstname;
         form.value.lastname = user.value.lastname;

--- a/packages/theme/pages/MyAccount.vue
+++ b/packages/theme/pages/MyAccount.vue
@@ -13,28 +13,52 @@
     >
       <SfContentCategory :title="$t('Personal Details')">
         <SfContentPage :title="$t('My profile')">
-          <MyProfile />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            :height="skeletonHeight"
+          />
+          <MyProfile v-else />
         </SfContentPage>
 
         <SfContentPage :title="$t('Addresses details')">
-          <AddressesDetails />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            :height="skeletonHeight"
+          />
+          <AddressesDetails v-else />
         </SfContentPage>
 
         <SfContentPage :title="$t('My newsletter')">
-          <MyNewsletter />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            :height="skeletonHeight"
+          />
+          <MyNewsletter v-else />
         </SfContentPage>
         <SfContentPage :title="$t('My wishlist')">
-          <MyWishlist />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            :height="skeletonHeight"
+          />
+          <MyWishlist v-else />
         </SfContentPage>
       </SfContentCategory>
 
       <SfContentCategory :title="$t('Order details')">
         <SfContentPage :title="$t('Order history')">
-          <OrderHistory />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            :height="skeletonHeight"
+          />
+          <OrderHistory v-else />
         </SfContentPage>
 
         <SfContentPage :title="$t('My reviews')">
-          <MyReviews />
+          <SkeletonLoader
+            v-if="$fetchState.pending"
+            height="100vh"
+          />
+          <MyReviews v-else />
         </SfContentPage>
       </SfContentCategory>
 
@@ -49,10 +73,12 @@ import {
   defineComponent,
   ref,
   useContext,
+  useFetch,
   useRoute,
   useRouter,
 } from '@nuxtjs/composition-api';
 import { useUser, useCart } from '~/composables';
+import SkeletonLoader from '~/components/SkeletonLoader/index.vue';
 import MyProfile from './MyAccount/MyProfile.vue';
 import AddressesDetails from './MyAccount/AddressesDetails.vue';
 import MyNewsletter from './MyAccount/MyNewsletter.vue';
@@ -71,6 +97,7 @@ export default defineComponent({
     OrderHistory,
     SfBreadcrumbs,
     SfContentPages,
+    SkeletonLoader,
   },
   middleware: [
     'is-authenticated',
@@ -78,9 +105,16 @@ export default defineComponent({
   setup() {
     const route = useRoute();
     const router = useRouter();
-    const { logout } = useUser();
+    const { logout, load: loadUser, user } = useUser();
     const { clear } = useCart();
     const { localePath, app } = useContext();
+
+    useFetch(async () => {
+      if (user.value === null) {
+        await loadUser();
+      }
+    });
+
     const breadcrumbs = ref([
       {
         text: app.i18n.t('Home'),
@@ -113,9 +147,11 @@ export default defineComponent({
     };
 
     return {
+      user,
       activePage,
       breadcrumbs,
       changeActivePage,
+      skeletonHeight: '100vh',
     };
   },
 });

--- a/packages/theme/pages/MyAccount/MyNewsletter.vue
+++ b/packages/theme/pages/MyAccount/MyNewsletter.vue
@@ -50,7 +50,7 @@
 import {
   SfTabs, SfCheckbox, SfButton, SfLink,
 } from '@storefront-ui/vue';
-import { defineComponent, ref, useFetch } from '@nuxtjs/composition-api';
+import { defineComponent, ref } from '@nuxtjs/composition-api';
 import { useUser } from '~/composables';
 
 export default defineComponent({
@@ -64,16 +64,11 @@ export default defineComponent({
   setup() {
     const {
       user,
-      load,
       updateUser,
       isAuthenticated,
     } = useUser();
 
     const isSubscribed = ref(!!user.value.is_subscribed);
-
-    useFetch(async () => {
-      await load();
-    });
 
     const saveForm = async () => {
       if (isAuthenticated.value && !!user.value.email) {

--- a/packages/theme/pages/MyAccount/MyProfile.vue
+++ b/packages/theme/pages/MyAccount/MyProfile.vue
@@ -36,7 +36,7 @@ import {
   confirmed,
 } from 'vee-validate/dist/rules';
 import { SfTabs } from '@storefront-ui/vue';
-import { defineComponent, useFetch } from '@nuxtjs/composition-api';
+import { defineComponent } from '@nuxtjs/composition-api';
 import { useUser } from '~/composables';
 import ProfileUpdateForm from '~/components/MyAccount/ProfileUpdateForm.vue';
 import PasswordResetForm from '~/components/MyAccount/PasswordResetForm.vue';
@@ -76,7 +76,6 @@ export default defineComponent({
     const {
       changePassword,
       errors,
-      load,
       loading,
       updateUser,
       error,
@@ -111,9 +110,6 @@ export default defineComponent({
       new: form.value.newPassword,
     }), onComplete, onError);
 
-    useFetch(async () => {
-      await load();
-    });
 
     return {
       loading,

--- a/packages/theme/pages/MyAccount/MyWishlist.vue
+++ b/packages/theme/pages/MyAccount/MyWishlist.vue
@@ -307,7 +307,7 @@ export default defineComponent({
     });
 
     const products = computed(() => wishlistGetters.getProducts(wishlist?.value));
-    const pagination = computed(() => wishlistGetters.getPagination(wishlist?.value[0]));
+    const pagination = computed(() => wishlistGetters.getPagination(wishlist?.value?.[0]));
 
     const addItemToCart = async ({ product, quantity }: { product: Product, quantity: number }) => {
       // eslint-disable-next-line no-underscore-dangle

--- a/packages/theme/stores/customer.ts
+++ b/packages/theme/stores/customer.ts
@@ -1,22 +1,26 @@
 import { defineStore } from 'pinia';
 import { Wishlist, Cart } from '~/modules/GraphQL/types';
-
-const wishlist: Wishlist = { items_count: 0 };
-const user: any = {};
-const cart: Cart = {
-  id: '', is_virtual: false, total_quantity: 0, shipping_addresses: [],
-};
+import { Customer } from '~/composables/useUser/useUser';
 
 interface CustomerState {
-  wishlist,
-  user,
-  cart,
+  wishlist: Wishlist,
+  cart: Cart,
+  user: Customer | null,
+  isLoggedIn: boolean,
 }
 
 export const useCustomerStore = defineStore('customer', {
   state: (): CustomerState => ({
-    wishlist,
-    user,
-    cart,
+    wishlist: { items_count: 0 },
+    user: null,
+    cart: {
+      id: '', is_virtual: false, total_quantity: 0, shipping_addresses: [],
+    },
+    isLoggedIn: false,
   }),
+  actions: {
+    setIsLoggedIn(isLoggedIn: boolean) {
+      this.isLoggedIn = isLoggedIn;
+    },
+  },
 });


### PR DESCRIPTION
wait for: https://github.com/vuestorefront/magento2/pull/862

Currently the user/customer object is pretty big and is excessive for checking if the user is logged in. A simple boolean should be sufficient.

Now instead of loading the user in the default layout, the login status is calculated outside of vue in the token-expired plugin at the start of the application

Also fixed the logic in MyAccount.vue where it'd excessively query for the user/customer object

- [ ] fix conflicts
- [ ] mark breaking change for login