### PR TITLE
feat!: make `useForgotPassword` properties readonly

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -104,7 +104,8 @@ module.exports = {
           ['/api-reference/magento-theme.useuserorder', 'useUserOrder()'],
           ['/api-reference/magento-theme.useexternalcheckout', 'useExternalCheckout()'],
           ['/api-reference/magento-theme.usewishlist', 'useWishlist()'],
-        ]
+          ['/api-reference/magento-theme.useforgotpassword', 'useForgotPassword()'],
+        ],
       },
       {
         title: 'API methods',
@@ -130,6 +131,8 @@ module.exports = {
           ['/api-reference/magento-api.customercart', 'customerCart'],
           ['/api-reference/magento-api.removeitemfromcart', 'removeItemFromCart'],
           ['/api-reference/magento-api.updatecartitems', 'updateCartItems'],
+          ['/api-reference/magento-api.resetpassword', 'resetPassword'],
+          ['/api-reference/magento-api.requestpasswordresetemail', 'requestPasswordResetEmail'],
         ],
       },
       {

--- a/packages/api-client/src/api/requestPasswordResetEmail/index.ts
+++ b/packages/api-client/src/api/requestPasswordResetEmail/index.ts
@@ -9,11 +9,17 @@ import {
 } from '../../types/GraphQL';
 import { Context } from '../../types/context';
 
-export default async (
+/**
+ * Requests a password reset email to be sent to the user
+ * @param context VSF Context
+ * @param input Email for which to request a password reset
+ * @param [customQuery] (optional) - custom GraphQL query that extends the default one
+ */
+export default async function requestPasswordResetEmail(
   context: Context,
   input: RequestPasswordResetEmailMutationVariables,
   customQuery: CustomQuery = { requestPasswordResetEmail: 'requestPasswordResetEmail' },
-): Promise<FetchResult<RequestPasswordResetEmailMutation>> => {
+): Promise<FetchResult<RequestPasswordResetEmailMutation>> {
   const {
     recaptchaToken, ...variables
   } = input;
@@ -32,7 +38,7 @@ export default async (
     }
   }
 
-  const { requestPasswordResetEmail } = context.extendQuery(customQuery, {
+  const { requestPasswordResetEmail: extendedMutation } = context.extendQuery(customQuery, {
     requestPasswordResetEmail: {
       query: requestPasswordResetEmailMutation,
       variables: { ...variables },
@@ -42,11 +48,11 @@ export default async (
   Logger.debug('[VSF: Magento] requestPasswordResetEmail', JSON.stringify(input, null, 2));
   const result = await context.client
     .mutate<RequestPasswordResetEmailMutation, RequestPasswordResetEmailMutationVariables>({
-    mutation: requestPasswordResetEmail.query,
-    variables: requestPasswordResetEmail.variables,
+    mutation: extendedMutation.query,
+    variables: extendedMutation.variables,
   });
 
   if (!result.data.requestPasswordResetEmail) throw new Error('Email was not found, or not available.');
 
   return result;
-};
+}

--- a/packages/api-client/src/api/requestPasswordResetEmail/requestPasswordResetEmail.ts
+++ b/packages/api-client/src/api/requestPasswordResetEmail/requestPasswordResetEmail.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 
+/** GraphQL Mutation that requests a password reset email to be sent */
 export default gql`
   mutation requestPasswordResetEmail($email: String!){
       requestPasswordResetEmail(email: $email)

--- a/packages/api-client/src/api/resetPassword/index.ts
+++ b/packages/api-client/src/api/resetPassword/index.ts
@@ -1,6 +1,5 @@
 import { FetchResult } from '@apollo/client/core';
 import { CustomQuery, Logger } from '@vue-storefront/core';
-import gql from 'graphql-tag';
 import { GraphQLError } from 'graphql';
 import resetPasswordMutation from './resetPassword';
 import {
@@ -10,11 +9,17 @@ import {
 import { Context } from '../../types/context';
 import recaptchaValidator from '../../helpers/recaptcha/recaptchaValidator';
 
-export default async (
+/**
+ * Resets a user's password
+ * @param contet VSF Context
+ * @param input Params used to reset a user's password
+ * @param [customQuery] (optional) - custom GraphQL query that extends the default one
+ */
+export default async function resetPassword(
   context: Context,
   input: ResetPasswordMutationVariables,
   customQuery: CustomQuery = { resetPassword: 'resetPassword' },
-): Promise<FetchResult<ResetPasswordMutation>> => {
+): Promise<FetchResult<ResetPasswordMutation>> {
   const {
     recaptchaToken, ...variables
   } = input;
@@ -33,7 +38,7 @@ export default async (
     }
   }
 
-  const { resetPassword } = context.extendQuery(customQuery, {
+  const { resetPassword: extendedResetPasswordMutation } = context.extendQuery(customQuery, {
     resetPassword: {
       query: resetPasswordMutation,
       variables: { ...variables },
@@ -43,11 +48,11 @@ export default async (
   Logger.debug('[VSF: Magento] requestPasswordResetEmail', JSON.stringify(input, null, 2));
   const result = await context.client
     .mutate<ResetPasswordMutation, ResetPasswordMutationVariables>({
-    mutation: resetPassword.query,
-    variables: resetPassword.variables,
+    mutation: extendedResetPasswordMutation.query,
+    variables: extendedResetPasswordMutation.variables,
   });
 
   if (!result.data.resetPassword) throw new Error('It was not possible to change the user password.');
 
   return result;
-};
+}

--- a/packages/api-client/src/api/resetPassword/resetPassword.ts
+++ b/packages/api-client/src/api/resetPassword/resetPassword.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 
+/** GraphQL Mutation that resets a users's password */
 export default gql`
   mutation resetPassword($email: String!, $newPassword: String!, $resetPasswordToken: String!){
     resetPassword(email: $email, newPassword: $newPassword, resetPasswordToken: $resetPasswordToken)

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -17,7 +17,7 @@ export * from './useExternalCheckout';
 export * from './useWishlist';
 export { default as useUser } from './useUser';
 export { default as useGuestUser } from './useGuestUser';
-export { default as useForgotPassword } from './useForgotPassword';
+export * from './useForgotPassword';
 export * from './useCategory';
 export { default as useFacet } from './useFacet';
 export * from './useCart';

--- a/packages/theme/composables/useForgotPassword/index.ts
+++ b/packages/theme/composables/useForgotPassword/index.ts
@@ -1,4 +1,5 @@
 import {
+  readonly,
   Ref,
   ref,
   useContext,
@@ -76,9 +77,9 @@ export function useForgotPassword(): UseForgotPasswordInterface {
   return {
     request: resetPassword,
     setNew: setNewPassword,
-    loading,
-    result,
-    error,
+    loading: readonly(loading),
+    result: readonly(result),
+    error: readonly(error),
   };
 }
 

--- a/packages/theme/composables/useForgotPassword/index.ts
+++ b/packages/theme/composables/useForgotPassword/index.ts
@@ -8,12 +8,17 @@ import { Logger } from '~/helpers/logger';
 import {
   UseForgotPasswordResults,
   UseForgotPasswordErrors,
-  ResetPasswordParams,
-  SetNewPasswordParams,
-  UseForgotPassword,
+  UseForgotPasswordResetParams,
+  UseForgotPasswordSetNewParams,
+  UseForgotPasswordInterface,
 } from '~/composables/useForgotPassword/useForgotPassword';
 
-export const useForgotPassword = (): UseForgotPassword => {
+/**
+ * The `useForgotPassword` composable alows to request a password reset email and to set a new password to a user
+ *
+ * Se the {@link UseForgotPasswordInterface} page for more information
+ */
+export function useForgotPassword(): UseForgotPasswordInterface {
   const { app } = useContext();
   const loading: Ref<boolean> = ref(false);
   const result: Ref<UseForgotPasswordResults> = ref({
@@ -26,7 +31,7 @@ export const useForgotPassword = (): UseForgotPassword => {
   });
 
   // eslint-disable-next-line @typescript-eslint/require-await,consistent-return
-  const resetPassword = async (resetPasswordParams: ComposableFunctionArgs<ResetPasswordParams>) => {
+  const resetPassword = async (resetPasswordParams: ComposableFunctionArgs<UseForgotPasswordResetParams>) => {
     Logger.debug('useForgotPassword/request', resetPasswordParams.email);
 
     try {
@@ -44,7 +49,7 @@ export const useForgotPassword = (): UseForgotPassword => {
     }
   };
 
-  const setNewPassword = async (setNewPasswordParams: ComposableFunctionArgs<SetNewPasswordParams>) => {
+  const setNewPassword = async (setNewPasswordParams: ComposableFunctionArgs<UseForgotPasswordSetNewParams>) => {
     Logger.debug('useForgotPassword/setNew', setNewPasswordParams);
 
     try {
@@ -75,6 +80,7 @@ export const useForgotPassword = (): UseForgotPassword => {
     result,
     error,
   };
-};
+}
 
+export * from './useForgotPassword';
 export default useForgotPassword;

--- a/packages/theme/composables/useForgotPassword/useForgotPassword.ts
+++ b/packages/theme/composables/useForgotPassword/useForgotPassword.ts
@@ -1,32 +1,44 @@
 import { Ref } from '@nuxtjs/composition-api';
 import { ComposableFunctionArgs } from '~/composables/types';
 
-export type UseForgotPasswordResults = {
-  resetPasswordResult: any,
-  setNewPasswordResult: any
-};
+/** Represents the result of a password change or reset operation */
+export interface UseForgotPasswordResults {
+  resetPasswordResult: any, // TODO: Add types
+  setNewPasswordResult: any // TODO: Add types
+}
 
+/** Errors returned by the {@link useForgotPassword} composable */
 export interface UseForgotPasswordErrors {
   request: Error;
   setNew: Error;
 }
 
-export interface ResetPasswordParams {
+/** Params used to request a password reset email */
+export interface UseForgotPasswordResetParams {
   email: string;
   recaptchaToken?: string;
 }
 
-export interface SetNewPasswordParams {
+/** Params used to set a new password to a user */
+export interface UseForgotPasswordSetNewParams {
   tokenValue: string;
   newPassword: string;
   email: string;
   recaptchaToken?: string;
 }
 
-export interface UseForgotPassword {
+/**
+ * Represents the data and methods returned by the {@link useForgotPassword} composable
+ */
+export interface UseForgotPasswordInterface {
+  /** Returns the result of the reset operation */
   result: Ref<UseForgotPasswordResults>;
+  /** Returns the loading state */
   loading: Ref<boolean>;
+  /** Returns possible errors */
   error: Ref<UseForgotPasswordErrors>;
-  setNew(params: ComposableFunctionArgs<SetNewPasswordParams>): Promise<void>;
-  request(params: ComposableFunctionArgs<ResetPasswordParams>): Promise<void>;
+  /** Sets the new password fot the user */
+  setNew (params: ComposableFunctionArgs<UseForgotPasswordSetNewParams>): Promise<void>;
+  /** Requests a new password reset email to be sent to user */
+  request(params: ComposableFunctionArgs<UseForgotPasswordResetParams>): Promise<void>;
 }

--- a/packages/theme/composables/useForgotPassword/useForgotPassword.ts
+++ b/packages/theme/composables/useForgotPassword/useForgotPassword.ts
@@ -1,4 +1,4 @@
-import { Ref } from '@nuxtjs/composition-api';
+import { DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import { ComposableFunctionArgs } from '~/composables/types';
 
 /** Represents the result of a password change or reset operation */
@@ -32,11 +32,11 @@ export interface UseForgotPasswordSetNewParams {
  */
 export interface UseForgotPasswordInterface {
   /** Returns the result of the reset operation */
-  result: Ref<UseForgotPasswordResults>;
+  result: DeepReadonly<Ref<UseForgotPasswordResults>>;
   /** Returns the loading state */
-  loading: Ref<boolean>;
+  loading: DeepReadonly<Ref<boolean>>;
   /** Returns possible errors */
-  error: Ref<UseForgotPasswordErrors>;
+  error: DeepReadonly<Ref<UseForgotPasswordErrors>>;
   /** Sets the new password fot the user */
   setNew (params: ComposableFunctionArgs<UseForgotPasswordSetNewParams>): Promise<void>;
   /** Requests a new password reset email to be sent to user */


### PR DESCRIPTION
This PR updates the `useForgotPassword` composable

- [BREAKING CHANGE] make `useForgotPassword` properties readonly
- add JSDoc to API client's `resetPassword`
- add JSDoc to `requestPasswordResetEmail`
- add `useForgotPassword` JSDoc
