### PR TITLE
perf: request speedcurve pref test run after develop deployment

### DIFF
--- a/.github/workflows/speedcurve.yml
+++ b/.github/workflows/speedcurve.yml
@@ -1,0 +1,20 @@
+name: "Run SpeedCurve test"
+
+on:
+  deployment_status:
+
+jobs:
+  speedcurve:
+    if: github.deployment.ref == 'refs/heads/develop' && github.event.deployment_status.state == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Wait for container deployed on VSF Cloud to come online'
+        run: 'sleep 300'
+        shell: 'bash'
+
+      - name: 'Ask SpeedCurve to run performance tests'
+        uses: SpeedCurve-Metrics/speedcurve-test-action@v1.2.1
+        with:
+          api_key: ${{ secrets.SPEEDCURVE_API_KEY }}
+          site_id: 744017
+          note: commit ${{ github.deployment.sha }} from deployment ${{ github.deployment.url }}


### PR DESCRIPTION
Asks speedcurve to run a preformance test automatically after each PR is merged to develop

To verify if this works I've temporarily added a "on: push" to the workflow and it did work:
https://github.com/vuestorefront/magento2/runs/6037564073?check_suite_focus=true

Obviously I can't deploy as part of a PR so unfortunately this'll have to be merged and "we'll see" with the next deploy