### PR TITLE
feat!: make `error` and `loading` properties readonly in `useGuestUser` composable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -106,6 +106,7 @@ module.exports = {
           ['/api-reference/magento-theme.useexternalcheckout', 'useExternalCheckout()'],
           ['/api-reference/magento-theme.usewishlist', 'useWishlist()'],
           ['/api-reference/magento-theme.useforgotpassword', 'useForgotPassword()'],
+          ['/api-reference/magento-theme.useguestuser', 'useGuestUser()'],
         ],
       },
       {
@@ -135,6 +136,7 @@ module.exports = {
           ['/api-reference/magento-api.updatecartitems', 'updateCartItems'],
           ['/api-reference/magento-api.resetpassword', 'resetPassword'],
           ['/api-reference/magento-api.requestpasswordresetemail', 'requestPasswordResetEmail'],
+          ['/api-reference/magento-api.setguestemailoncart', 'setGuestEmailOnCart'],
         ],
       },
       {

--- a/packages/api-client/src/api/setGuestEmailOnCart/index.ts
+++ b/packages/api-client/src/api/setGuestEmailOnCart/index.ts
@@ -1,21 +1,27 @@
 import { FetchResult } from '@apollo/client/core';
 import { CustomQuery } from '@vue-storefront/core';
-import setGuestEmailOnCart from './setGuestEmailOnCart';
+import setGuestEmailOnCartMutation from './setGuestEmailOnCart';
 import {
   SetGuestEmailOnCartInput, SetGuestEmailOnCartMutation, SetGuestEmailOnCartMutationVariables,
 } from '../../types/GraphQL';
 import { Context } from '../../types/context';
 
-export default async (
+/**
+ * Set the guest user email on the cart
+ * @param context VSF Context
+ * @param input Variables to set guest email
+ * @param [customQuery] (optional) - Custom query that will extend default one
+ */
+export default async function setGuestEmailOnCart(
   context: Context,
   input: SetGuestEmailOnCartInput,
   customQuery: CustomQuery = { setGuestEmailOnCart: 'setGuestEmailOnCart' },
-): Promise<FetchResult<SetGuestEmailOnCartMutation>> => {
+): Promise<FetchResult<SetGuestEmailOnCartMutation>> {
   const { setGuestEmailOnCart: setGuestEmailOnCartGQL } = context.extendQuery(
     customQuery,
     {
       setGuestEmailOnCart: {
-        query: setGuestEmailOnCart,
+        query: setGuestEmailOnCartMutation,
         variables: { input },
       },
     },
@@ -25,4 +31,4 @@ export default async (
     mutation: setGuestEmailOnCartGQL.query,
     variables: setGuestEmailOnCartGQL.variables,
   });
-};
+}

--- a/packages/api-client/src/api/setGuestEmailOnCart/setGuestEmailOnCart.ts
+++ b/packages/api-client/src/api/setGuestEmailOnCart/setGuestEmailOnCart.ts
@@ -1,5 +1,6 @@
 import gql from 'graphql-tag';
 
+/** GraphQL Mutation that sets the guest user email on a cart */
 export default gql`
   mutation setGuestEmailOnCart($input: SetGuestEmailOnCartInput) {
     setGuestEmailOnCart(input: $input) {

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -16,7 +16,7 @@ export * from './useCurrency';
 export * from './useExternalCheckout';
 export * from './useWishlist';
 export { default as useUser } from './useUser';
-export { default as useGuestUser } from './useGuestUser';
+export * from './useGuestUser';
 export * from './useForgotPassword';
 export * from './useCategory';
 export { default as useFacet } from './useFacet';

--- a/packages/theme/composables/useGuestUser/index.ts
+++ b/packages/theme/composables/useGuestUser/index.ts
@@ -1,10 +1,15 @@
 import { ref, useContext } from '@nuxtjs/composition-api';
 import { ComposableFunctionArgs } from '~/composables/types';
 import { Logger } from '~/helpers/logger';
-import { AttachToCartParams, UseGuestUser, UseGuestUserErrors } from '~/composables/useGuestUser/useGuestUser';
+import { AttachToCartParams, UseGuestUserInterface, UseGuestUserErrors } from '~/composables/useGuestUser/useGuestUser';
 import { attachToCartCommand } from '~/composables/useGuestUser/commands/attachToCartCommand';
 
-export const useGuestUser = <PARAMS extends AttachToCartParams>(): UseGuestUser<PARAMS> => {
+/**
+ * The `useGuestUser` composable allows to attach a guest cart to a user
+ *
+ * See {@link UseGuestUserInterface} page for more information
+ */
+export function useGuestUser<PARAMS extends AttachToCartParams>(): UseGuestUserInterface<PARAMS> {
   const loading = ref(false);
   const error = ref<UseGuestUserErrors>({ attachToCart: null });
   const { app } = useContext();
@@ -31,6 +36,7 @@ export const useGuestUser = <PARAMS extends AttachToCartParams>(): UseGuestUser<
     loading,
     error,
   };
-};
+}
 
+export * from './useGuestUser';
 export default useGuestUser;

--- a/packages/theme/composables/useGuestUser/index.ts
+++ b/packages/theme/composables/useGuestUser/index.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api';
+import { readonly, ref, useContext } from '@nuxtjs/composition-api';
 import { ComposableFunctionArgs } from '~/composables/types';
 import { Logger } from '~/helpers/logger';
 import { AttachToCartParams, UseGuestUserInterface, UseGuestUserErrors } from '~/composables/useGuestUser/useGuestUser';
@@ -33,8 +33,8 @@ export function useGuestUser<PARAMS extends AttachToCartParams>(): UseGuestUserI
 
   return {
     attachToCart,
-    loading,
-    error,
+    loading: readonly(loading),
+    error: readonly(error),
   };
 }
 

--- a/packages/theme/composables/useGuestUser/useGuestUser.ts
+++ b/packages/theme/composables/useGuestUser/useGuestUser.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, Ref } from '@nuxtjs/composition-api';
+import { ComputedRef, DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import { PlatformApi, Composable, ComposableFunctionArgs } from '~/composables/types';
 import { Cart } from '~/modules/GraphQL/types';
 
@@ -19,7 +19,7 @@ export interface UseGuestUserInterface<REGISTER_GUEST_USER_PARAMS extends Attach
   /** Attaches guest cart to user */
   attachToCart(params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>): Promise<void>;
   /** Indicates the loading state for `attachToCart` */
-  loading: Ref<boolean>;
+  loading: DeepReadonly<Ref<boolean>>;
   /** Possible errors when calling `attachToCart` */
-  error: Ref<UseGuestUserErrors>;
+  error: DeepReadonly<Ref<UseGuestUserErrors>>;
 }

--- a/packages/theme/composables/useGuestUser/useGuestUser.ts
+++ b/packages/theme/composables/useGuestUser/useGuestUser.ts
@@ -2,18 +2,24 @@ import { ComputedRef, Ref } from '@nuxtjs/composition-api';
 import { PlatformApi, Composable, ComposableFunctionArgs } from '~/composables/types';
 import { Cart } from '~/modules/GraphQL/types';
 
+/** Errors returned by the {@link useGuestUser} composable */
 export interface UseGuestUserErrors {
   attachToCart: Error;
 }
 
+/** Params used by {@link useGuestUser} composable's `attachToCart` method */
 export interface AttachToCartParams {
   email: string;
   cart: ComputedRef<Cart>,
   [x: string]: any;
 }
 
-export interface UseGuestUser<REGISTER_GUEST_USER_PARAMS extends AttachToCartParams, API extends PlatformApi = any> extends Composable<API> {
-  attachToCart: (params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>) => Promise<void>;
+/** Represents the data and methods returned by the {@link useGuestUser}  composable */
+export interface UseGuestUserInterface<REGISTER_GUEST_USER_PARAMS extends AttachToCartParams, API extends PlatformApi = any> extends Composable<API> {
+  /** Attaches guest cart to user */
+  attachToCart(params: ComposableFunctionArgs<REGISTER_GUEST_USER_PARAMS>): Promise<void>;
+  /** Indicates the loading state for `attachToCart` */
   loading: Ref<boolean>;
+  /** Possible errors when calling `attachToCart` */
   error: Ref<UseGuestUserErrors>;
 }


### PR DESCRIPTION
This PR updates the `useGuestUser` composable:

- [BREAKIGN CHANGE] make properties readonly on `useGuestUser`
- add `setGuestEmailOnCart` JSDoc
- add JSDoc to `useGuestUser` composable
