### PR TITLE
feat!: make `error` and `loading` properties readonly on `useUserAddress` composable

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -106,6 +106,7 @@ module.exports = {
           ['/api-reference/magento-theme.useexternalcheckout', 'useExternalCheckout()'],
           ['/api-reference/magento-theme.usewishlist', 'useWishlist()'],
           ['/api-reference/magento-theme.useforgotpassword', 'useForgotPassword()'],
+          ['/api-reference/magento-theme.useuseraddress', 'useUserAddress()'],
         ],
       },
       {

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -34,7 +34,7 @@ export { default as usePaymentProvider } from './usePaymentProvider';
 export * from './useAddresses';
 export { default as useMakeOrder } from './useMakeOrder';
 export * from './useUserOrder';
-export { default as useUserAddress } from './useUserAddress';
+export * from './useUserAddress';
 export * from './useCountrySearch';
 
 export * from './types';

--- a/packages/theme/composables/useUserAddress/index.ts
+++ b/packages/theme/composables/useUserAddress/index.ts
@@ -1,15 +1,27 @@
-import { Ref, ref, useContext } from '@nuxtjs/composition-api';
+import { ref, readonly, useContext } from '@nuxtjs/composition-api';
+import type { Ref } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
-import { UseUserAddressErrors } from '~/composables/useUserAddress/useUserAddress';
 import { useUser } from '~/composables';
 import { transformUserCreateAddressInput, transformUserUpdateAddressInput } from '~/helpers/userAddressManipulator';
-import { createCustomerAddressCommand } from '~/composables/useUserAddress/commands/createCustomerAddressCommand';
-import { deleteCustomerAddressCommand } from '~/composables/useUserAddress/commands/deleteCustomerAddressCommand';
-import { updateCustomerAddressCommand } from '~/composables/useUserAddress/commands/updateCustomerAddressCommand';
+import { createCustomerAddressCommand } from './commands/createCustomerAddressCommand';
+import { deleteCustomerAddressCommand } from './commands/deleteCustomerAddressCommand';
+import { updateCustomerAddressCommand } from './commands/updateCustomerAddressCommand';
 import { CustomerAddress } from '~/modules/GraphQL/types';
 import mask from '../utils/mask';
+import type {
+  UseUserAddressErrors,
+  UseUserAddressInterface,
+  UseUserAddressAddAddressParams,
+  UseUserAddressUpdateAddressParams,
+  UseUserAddressSetDefaultAddressParams,
+} from './useUserAddress';
 
-export const useUserAddress = () => {
+/**
+ * The `useUserAddress()` composable allows loading and manipulating addresses of the current user.
+ *
+ * See the {@link UseUserAddressInterface} page for more information.
+ */
+export function useUserAddress(): UseUserAddressInterface {
   const loading = ref(false);
   const shipping = ref({});
   const error: Ref<UseUserAddressErrors> = ref({
@@ -22,7 +34,7 @@ export const useUserAddress = () => {
   const { user, load: loadUser } = useUser();
   const context = useContext();
 
-  const addAddress = async ({ address, customQuery }: { address: CustomerAddress, customQuery: any }) => {
+  const addAddress = async ({ address, customQuery }: UseUserAddressAddAddressParams) => {
     Logger.debug('useUserAddress.addAddress', mask(address));
     let result = {};
     try {
@@ -66,7 +78,7 @@ export const useUserAddress = () => {
     return result;
   };
 
-  const updateAddress = async ({ address, customQuery }: { address: CustomerAddress, customQuery: any }) => {
+  const updateAddress = async ({ address, customQuery }: UseUserAddressUpdateAddressParams) => {
     Logger.debug('useUserAddress.updateAddress', mask(address));
     let result = {};
 
@@ -109,7 +121,7 @@ export const useUserAddress = () => {
     return user?.value;
   };
 
-  const setDefaultAddress = async ({ address, customQuery }: { address: CustomerAddress, customQuery: any }) => {
+  const setDefaultAddress = async ({ address, customQuery }: UseUserAddressSetDefaultAddressParams) => {
     Logger.debug('useUserAddress.setDefaultAddress', mask(address));
     let result = {};
 
@@ -136,14 +148,15 @@ export const useUserAddress = () => {
   };
 
   return {
-    loading,
-    error,
     addAddress,
     deleteAddress,
     updateAddress,
     load,
     setDefaultAddress,
+    loading: readonly(loading),
+    error: readonly(error),
   };
-};
+}
 
 export default useUserAddress;
+export * from './useUserAddress';

--- a/packages/theme/composables/useUserAddress/useUserAddress.ts
+++ b/packages/theme/composables/useUserAddress/useUserAddress.ts
@@ -1,7 +1,76 @@
+import type { Ref, DeepReadonly } from '@nuxtjs/composition-api';
+import type { Customer } from '~/composables/useUser/useUser';
+import type { CustomerAddress } from '~/modules/GraphQL/types';
+import type { ComposableFunctionArgs } from '~/composables/types';
+
+/**
+ * Errors that occured in the `useUserAddress` composable
+ */
 export interface UseUserAddressErrors {
-  addAddress: Error;
-  deleteAddress: Error;
-  updateAddress: Error;
-  load: Error;
-  setDefaultAddress: Error;
+  addAddress: Error | null;
+  deleteAddress: Error | null;
+  updateAddress: Error | null;
+  load: Error | null;
+  setDefaultAddress: Error | null;
+}
+
+/**
+ * Parameters accepted by the `addAddress` method in the `useUserAddress` composable
+ */
+export type UseUserAddressAddAddressParams = ComposableFunctionArgs<{
+  address: CustomerAddress;
+}>;
+
+/**
+ * Parameters accepted by the `updateAddress` method in the `useUserAddress` composable
+ */
+export type UseUserAddressUpdateAddressParams = ComposableFunctionArgs<{
+  address: CustomerAddress;
+}>;
+
+/**
+ * Parameters accepted by the `setDefaultAddress` method in the `useUserAddress` composable
+ */
+export type UseUserAddressSetDefaultAddressParams = ComposableFunctionArgs<{
+  address: CustomerAddress;
+}>;
+
+/**
+ * Represents the data returned from and functions available in the `useUserAddress()` composable.
+ */
+export interface UseUserAddressInterface {
+  /**
+   * Adds address to the profile of the current user
+   */
+  addAddress(params: UseUserAddressAddAddressParams): Promise<CustomerAddress>;
+
+  /**
+   * Deletes address from the profile of the current user
+   */
+  deleteAddress(address: CustomerAddress): Promise<boolean | {}>; // TODO: Should accept custom queries
+
+  /**
+   * Updates an existing address from the profile of the current user
+   */
+  updateAddress(params: UseUserAddressUpdateAddressParams): Promise<CustomerAddress>;
+
+  /**
+   * Loads addresses from the profile of the current user
+   */
+  load(force?: boolean): Promise<Customer>; // TODO: Should accept custom queries
+
+  /**
+   * Sets an existing address as the default for the current user
+   */
+  setDefaultAddress(params: UseUserAddressSetDefaultAddressParams): Promise<CustomerAddress>;
+
+  /**
+   * Indicates whether any of the methods is in progress
+   */
+  loading: DeepReadonly<Ref<boolean>>;
+
+  /**
+   * Contains errors from any of the composable methods
+   */
+  error: DeepReadonly<Ref<UseUserAddressErrors>>;
 }


### PR DESCRIPTION
This PR updates the `useUserAddress` composable:

- [BREAKING CHANGE] wraps the `loading` and `error` objects with `readonly` so they cannot be manipulated outside of the composable,
- improves typing,
- adds a short description to all interfaces, types, and properties.