### PR TITLE
feat!: refactor `useProduct` composable `error` and make its refs readonly

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -137,6 +137,7 @@ module.exports = {
           ['/api-reference/magento-api.updatecartitems', 'updateCartItems'],
           ['/api-reference/magento-api.resetpassword', 'resetPassword'],
           ['/api-reference/magento-api.requestpasswordresetemail', 'requestPasswordResetEmail'],
+          ['/api-reference/magento-api.productdetail', 'productDetail'],
         ],
       },
       {

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -106,6 +106,7 @@ module.exports = {
           ['/api-reference/magento-theme.useexternalcheckout', 'useExternalCheckout()'],
           ['/api-reference/magento-theme.usewishlist', 'useWishlist()'],
           ['/api-reference/magento-theme.useforgotpassword', 'useForgotPassword()'],
+          ['/api-reference/magento-theme.useproduct', 'useProduct()'],
           ['/api-reference/magento-theme.useuseraddress', 'useUserAddress()'],
         ],
       },

--- a/packages/api-client/src/api/productDetail/productDetailsQuery.ts
+++ b/packages/api-client/src/api/productDetail/productDetailsQuery.ts
@@ -1,5 +1,9 @@
 import gql from 'graphql-tag';
 
+/**
+ * GraphQL Query that fetches the list of products with details using sort,
+ * filters and pagination.
+ */
 export default gql`
   query productDetails(
     $search: String = "",

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -23,7 +23,7 @@ export { default as useFacet } from './useFacet';
 export * from './useCart';
 export * from './useContent';
 export * from './useCategorySearch';
-export { default as useProduct } from './useProduct';
+export * from './useProduct';
 export { default as useReview } from './useReview';
 export { default as useShipping } from './useShipping';
 export { default as useShippingProvider } from './useShippingProvider';

--- a/packages/theme/composables/useProduct/commands/getProductDetailsCommand.ts
+++ b/packages/theme/composables/useProduct/commands/getProductDetailsCommand.ts
@@ -1,14 +1,10 @@
-import { GetProductSearchParams } from '~/composables/useProduct/useProduct';
-import { VsfContext } from '~/composables/context';
+import type { NuxtAppOptions } from '@nuxt/types';
+import type { GetProductSearchParams } from '~/composables/types';
 
 export const getProductDetailsCommand = {
-  execute: async (context: VsfContext, searchParams, customQuery = { productDetail: 'productDetail' }) => {
-    const result = await context
-      .$magento
-      .api
-      .productDetail({
-        ...searchParams,
-      } as GetProductSearchParams, customQuery);
-    return result.data?.products;
+  execute: async (app: NuxtAppOptions, searchParams: GetProductSearchParams, customQuery = { productDetail: 'productDetail' }) => {
+    const { data } = await app.$vsf.$magento.api.productDetail(searchParams, customQuery);
+
+    return data?.products ?? null;
   },
 };

--- a/packages/theme/composables/useProduct/commands/getProductListCommand.ts
+++ b/packages/theme/composables/useProduct/commands/getProductListCommand.ts
@@ -1,13 +1,10 @@
-import { GetProductSearchParams } from '~/composables/useProduct/useProduct';
-import { VsfContext } from '~/composables/context';
+import type { NuxtAppOptions } from '@nuxt/types';
+import type { GetProductSearchParams } from '../useProduct';
 
 export const getProductListCommand = {
-  execute: async (context: VsfContext, searchParams, customQuery = { products: 'products' }) => {
-    const result = await context
-      .$magento
-      .api
-      .products(searchParams as GetProductSearchParams, customQuery);
+  execute: async (app: NuxtAppOptions, searchParams: GetProductSearchParams, customQuery = { products: 'products' }) => {
+    const { data } = await app.$vsf.$magento.api.products(searchParams, customQuery);
 
-    return result.data?.products;
+    return data?.products ?? null;
   },
 };

--- a/packages/theme/composables/useProduct/commands/getProductListCommand.ts
+++ b/packages/theme/composables/useProduct/commands/getProductListCommand.ts
@@ -1,5 +1,5 @@
 import type { NuxtAppOptions } from '@nuxt/types';
-import type { GetProductSearchParams } from '../useProduct';
+import type { GetProductSearchParams } from '~/composables/types';
 
 export const getProductListCommand = {
   execute: async (app: NuxtAppOptions, searchParams: GetProductSearchParams, customQuery = { products: 'products' }) => {

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -1,4 +1,4 @@
-import { ref, useContext } from '@nuxtjs/composition-api';
+import { readonly, ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import { getProductListCommand } from '~/composables/useProduct/commands/getProductListCommand';
 import { getProductDetailsCommand } from '~/composables/useProduct/commands/getProductDetailsCommand';
@@ -57,8 +57,8 @@ export const useProduct = (id?: string): UseProductInterface => {
   return {
     getProductList,
     getProductDetails,
-    loading,
-    error,
+    error: readonly(error),
+    loading: readonly(loading),
   };
 };
 

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -10,6 +10,10 @@ import type {
   UseProductInterface,
 } from './useProduct';
 
+/**
+ * The `useProduct()` composable allows loading product details or list with
+ * params for sorting, filtering and pagination.
+ */
 export function useProduct(id?: string): UseProductInterface {
   const loading = ref(false);
   const error = ref<UseProductErrors>({

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -2,20 +2,25 @@ import { ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import { getProductListCommand } from '~/composables/useProduct/commands/getProductListCommand';
 import { getProductDetailsCommand } from '~/composables/useProduct/commands/getProductDetailsCommand';
-import { ProductsListQuery } from '~/modules/GraphQL/types';
-import { GetProductSearchParams } from '~/composables/types';
+import type {
+  ProductDetails,
+  ProductList,
+  UseProductErrors,
+  UseProductInterface,
+  GetProductSearchParams,
+} from './useProduct';
 
-export const useProduct = (id?: string) => {
+export const useProduct = (id?: string): UseProductInterface => {
   const loading = ref(false);
-  const error = ref({
+  const error = ref<UseProductErrors>({
     search: null,
   });
 
   const { app } = useContext();
 
-  const getProductList = async (searchParams: GetProductSearchParams) => {
+  const getProductList = async (searchParams: GetProductSearchParams): Promise<ProductList | null> => {
     Logger.debug(`useProduct/${id}/getProductList`, searchParams);
-    let products : ProductsListQuery['products'] = null;
+    let products: ProductList = null;
 
     try {
       loading.value = true;
@@ -31,9 +36,9 @@ export const useProduct = (id?: string) => {
     return products;
   };
 
-  const getProductDetails = async (searchParams: GetProductSearchParams) => {
+  const getProductDetails = async (searchParams: GetProductSearchParams): Promise<ProductDetails | null> => {
     Logger.debug(`useProduct/${id}/getProductDetails`, searchParams);
-    let products : ProductsListQuery['products'] = null;
+    let products: ProductDetails = null;
 
     try {
       loading.value = true;
@@ -57,4 +62,5 @@ export const useProduct = (id?: string) => {
   };
 };
 
+export * from './useProduct';
 export default useProduct;

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -17,7 +17,8 @@ import type {
 export function useProduct(id?: string): UseProductInterface {
   const loading = ref(false);
   const error = ref<UseProductErrors>({
-    search: null,
+    getProductList: null,
+    getProductDetails: null,
   });
 
   const { app } = useContext();
@@ -29,9 +30,9 @@ export function useProduct(id?: string): UseProductInterface {
     try {
       loading.value = true;
       products = await getProductListCommand.execute(app, searchParams);
-      error.value.search = null;
+      error.value.getProductList = null;
     } catch (err) {
-      error.value.search = err;
+      error.value.getProductList = err;
       Logger.error(`useProduct/${id}/search`, err);
     } finally {
       loading.value = false;
@@ -47,9 +48,9 @@ export function useProduct(id?: string): UseProductInterface {
     try {
       loading.value = true;
       products = await getProductDetailsCommand.execute(app, searchParams);
-      error.value.search = null;
+      error.value.getProductDetails = null;
     } catch (err) {
-      error.value.search = err;
+      error.value.getProductDetails = err;
       Logger.error(`useProduct/${id}/search`, err);
     } finally {
       loading.value = false;

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -10,7 +10,7 @@ import type {
   UseProductInterface,
 } from './useProduct';
 
-export const useProduct = (id?: string): UseProductInterface => {
+export function useProduct(id?: string): UseProductInterface {
   const loading = ref(false);
   const error = ref<UseProductErrors>({
     search: null,
@@ -60,7 +60,7 @@ export const useProduct = (id?: string): UseProductInterface => {
     error: readonly(error),
     loading: readonly(loading),
   };
-};
+}
 
 export * from './useProduct';
 export default useProduct;

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -2,12 +2,12 @@ import { ref, useContext } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
 import { getProductListCommand } from '~/composables/useProduct/commands/getProductListCommand';
 import { getProductDetailsCommand } from '~/composables/useProduct/commands/getProductDetailsCommand';
+import type { GetProductSearchParams } from '~/composables/types';
 import type {
   ProductDetails,
   ProductList,
   UseProductErrors,
   UseProductInterface,
-  GetProductSearchParams,
 } from './useProduct';
 
 export const useProduct = (id?: string): UseProductInterface => {

--- a/packages/theme/composables/useProduct/index.ts
+++ b/packages/theme/composables/useProduct/index.ts
@@ -3,6 +3,7 @@ import { Logger } from '~/helpers/logger';
 import { getProductListCommand } from '~/composables/useProduct/commands/getProductListCommand';
 import { getProductDetailsCommand } from '~/composables/useProduct/commands/getProductDetailsCommand';
 import { ProductsListQuery } from '~/modules/GraphQL/types';
+import { GetProductSearchParams } from '~/composables/types';
 
 export const useProduct = (id?: string) => {
   const loading = ref(false);
@@ -11,15 +12,14 @@ export const useProduct = (id?: string) => {
   });
 
   const { app } = useContext();
-  const context = app.$vsf;
 
-  const getProductList = async (searchParams) => {
+  const getProductList = async (searchParams: GetProductSearchParams) => {
     Logger.debug(`useProduct/${id}/getProductList`, searchParams);
     let products : ProductsListQuery['products'] = null;
 
     try {
       loading.value = true;
-      products = await getProductListCommand.execute(context, searchParams);
+      products = await getProductListCommand.execute(app, searchParams);
       error.value.search = null;
     } catch (err) {
       error.value.search = err;
@@ -31,13 +31,13 @@ export const useProduct = (id?: string) => {
     return products;
   };
 
-  const getProductDetails = async (searchParams) => {
+  const getProductDetails = async (searchParams: GetProductSearchParams) => {
     Logger.debug(`useProduct/${id}/getProductDetails`, searchParams);
     let products : ProductsListQuery['products'] = null;
 
     try {
       loading.value = true;
-      products = await getProductDetailsCommand.execute(context, searchParams);
+      products = await getProductDetailsCommand.execute(app, searchParams);
       error.value.search = null;
     } catch (err) {
       error.value.search = err;

--- a/packages/theme/composables/useProduct/useProduct.ts
+++ b/packages/theme/composables/useProduct/useProduct.ts
@@ -1,19 +1,6 @@
 import type { Ref } from '@nuxtjs/composition-api';
-import type {
-  ProductAttributeFilterInput,
-  ProductAttributeSortInput,
-  ProductsListQuery,
-  ProductDetailsQuery,
-} from '~/modules/GraphQL/types';
-
-export declare type GetProductSearchParams = {
-  pageSize?: number;
-  currentPage?: number;
-  search?: string;
-  filter?: ProductAttributeFilterInput;
-  sort?: ProductAttributeSortInput;
-  configurations?: string[];
-};
+import type { ProductsListQuery, ProductDetailsQuery } from '~/modules/GraphQL/types';
+import type { GetProductSearchParams } from '~/composables/types';
 
 export type ProductList = ProductsListQuery['products'];
 

--- a/packages/theme/composables/useProduct/useProduct.ts
+++ b/packages/theme/composables/useProduct/useProduct.ts
@@ -1,4 +1,10 @@
-import { ProductAttributeFilterInput, ProductAttributeSortInput } from '~/modules/GraphQL/types';
+import type { Ref } from '@nuxtjs/composition-api';
+import type {
+  ProductAttributeFilterInput,
+  ProductAttributeSortInput,
+  ProductsListQuery,
+  ProductDetailsQuery,
+} from '~/modules/GraphQL/types';
 
 export declare type GetProductSearchParams = {
   pageSize?: number;
@@ -8,3 +14,18 @@ export declare type GetProductSearchParams = {
   sort?: ProductAttributeSortInput;
   configurations?: string[];
 };
+
+export type ProductList = ProductsListQuery['products'];
+
+export type ProductDetails = ProductDetailsQuery['products'];
+
+export interface UseProductErrors {
+  search: Error | null;
+}
+
+export interface UseProductInterface {
+  error: Ref<UseProductErrors>;
+  loading: Ref<boolean>;
+  getProductList(searchParams: GetProductSearchParams): Promise<ProductList | null>;
+  getProductDetails(searchParams: GetProductSearchParams): Promise<ProductDetails | null>;
+}

--- a/packages/theme/composables/useProduct/useProduct.ts
+++ b/packages/theme/composables/useProduct/useProduct.ts
@@ -6,13 +6,33 @@ export type ProductList = ProductsListQuery['products'];
 
 export type ProductDetails = ProductDetailsQuery['products'];
 
+/**
+ * The {@link useProduct} error object. The properties values' are the errors
+ * thrown by its methods.
+ */
 export interface UseProductErrors {
+  /**
+   * Error when fetching the product list or product details method fails,
+   * otherwise is `null`.
+   */
   search: Error | null;
 }
 
+/** The interface provided by {@link useProduct} composable. */
 export interface UseProductInterface {
+  /**
+   * Contains errors from any of the composable methods.
+   *
+   * @see {@link UseProductErrors} documentation for more details.
+   */
   error: DeepReadonly<Ref<UseProductErrors>>;
+
+  /** Indicates whether any of the composable methods is in progress. */
   loading: Readonly<Ref<boolean>>;
+
+  /** Fetches a list of products with sorting, filtering and pagination. */
   getProductList(searchParams: GetProductSearchParams): Promise<ProductList | null>;
+
+  /** Fetches a product details with sorting, filtering and pagination. */
   getProductDetails(searchParams: GetProductSearchParams): Promise<ProductDetails | null>;
 }

--- a/packages/theme/composables/useProduct/useProduct.ts
+++ b/packages/theme/composables/useProduct/useProduct.ts
@@ -1,4 +1,4 @@
-import type { Ref } from '@nuxtjs/composition-api';
+import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
 import type { ProductsListQuery, ProductDetailsQuery } from '~/modules/GraphQL/types';
 import type { GetProductSearchParams } from '~/composables/types';
 
@@ -11,8 +11,8 @@ export interface UseProductErrors {
 }
 
 export interface UseProductInterface {
-  error: Ref<UseProductErrors>;
-  loading: Ref<boolean>;
+  error: DeepReadonly<Ref<UseProductErrors>>;
+  loading: Readonly<Ref<boolean>>;
   getProductList(searchParams: GetProductSearchParams): Promise<ProductList | null>;
   getProductDetails(searchParams: GetProductSearchParams): Promise<ProductDetails | null>;
 }

--- a/packages/theme/composables/useProduct/useProduct.ts
+++ b/packages/theme/composables/useProduct/useProduct.ts
@@ -11,11 +11,11 @@ export type ProductDetails = ProductDetailsQuery['products'];
  * thrown by its methods.
  */
 export interface UseProductErrors {
-  /**
-   * Error when fetching the product list or product details method fails,
-   * otherwise is `null`.
-   */
-  search: Error | null;
+  /** Error when fetching the product list method fails, otherwise is `null`. */
+  getProductList: Error | null;
+
+  /** Error when fetching product details method fails, otherwise is `null`. */
+  getProductDetails: Error | null;
 }
 
 /** The interface provided by {@link useProduct} composable. */


### PR DESCRIPTION
## Description
- **[BREAKING CHANGE]** Make the `loading` and `error` ref readonly;
- **[BREAKING CHANGE]** Refactor `error` ref to expose errors using the same property names as the composable itself;
- **[BREAKING CHANGE]** Remove repeated declaration for `GetProductSearchParams` on `~/composables/useProduct/useProduct`;
- Add types and interfaces for the `useProduct` composable;
- Define types and use `context.app` instead of `context` in `useProduct` commands;
- Write TSDoc comments for `useProduct` and its types;
- Write TSDoc comments for `productDetail` and its GraphQL Query;
- Change `useProduct` and `productDetail` to function declaration (since it's better for the docs generator).

## Related Issue
https://vsf.atlassian.net/browse/M2-390

## Motivation and Context
Improves the DX of the `useProduct` composable.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
