### PR TITLE
feat!: make `error` and `loading` properties readonly on `useStore` composble

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -111,6 +111,7 @@ module.exports = {
           ['/api-reference/magento-theme.useimage', 'useImage()'],
           ['/api-reference/magento-theme.usenewsletter', 'useNewsletter()'],
           ['/api-reference/magento-theme.usepaymentprovider', 'usePaymentProvider()'],
+          ['/api-reference/magento-theme.usestore.html', 'useStore()'],
           ['/api-reference/magento-theme.useuistate.html', 'useUiState()'],
           ['/api-reference/magento-theme.useupsellproducts.html', 'useUpsellProducts()'],
           ['/api-reference/magento-theme.useuser', 'useUser()'],

--- a/packages/api-client/src/api/availableStores/index.ts
+++ b/packages/api-client/src/api/availableStores/index.ts
@@ -6,6 +6,9 @@ import {
 import availableStores from './availableStores';
 import { Context } from '../../types/context';
 
+/**
+ * Returns list of available stores
+ */
 export default async (
   context: Context,
   customQuery: CustomQuery = { availableStores: 'availableStores' },

--- a/packages/theme/composables/index.ts
+++ b/packages/theme/composables/index.ts
@@ -29,7 +29,7 @@ export { default as useRelatedProducts } from './useRelatedProducts';
 export { default as useReview } from './useReview';
 export { default as useShipping } from './useShipping';
 export { default as useShippingProvider } from './useShippingProvider';
-export { default as useStore } from './useStore';
+export * from './useStore';
 export { default as useUiHelpers } from './useUiHelpers';
 export { default as useUiNotification } from './useUiNotification';
 export * from './useUiState';

--- a/packages/theme/composables/types.ts
+++ b/packages/theme/composables/types.ts
@@ -70,11 +70,6 @@ export declare type CustomerProductReviewParams = {
   currentPage: number;
 };
 
-export interface UseStoreErrors {
-  load: Error | null;
-  change: Error | null;
-}
-
 export declare type GetProductSearchParams = {
   pageSize?: number;
   currentPage?: number;

--- a/packages/theme/composables/useStore/index.ts
+++ b/packages/theme/composables/useStore/index.ts
@@ -1,17 +1,27 @@
 import {
   computed,
-  ref, Ref, useContext,
+  readonly,
+  ref,
+  useContext,
 } from '@nuxtjs/composition-api';
+import type { Ref } from '@nuxtjs/composition-api';
 import { Logger } from '~/helpers/logger';
-import { StoreConfig } from '~/modules/GraphQL/types';
-import { UseStoreInterface, UseStore, UseStoreErrors } from '~/composables/useStore/useStore';
 import { useConfigStore } from '~/stores/config';
+import type { StoreConfig } from '~/modules/GraphQL/types';
+import type { UseStoreInterface, UseStoreErrors } from '~/composables/useStore/useStore';
 
-const useStore: UseStore = (): UseStoreInterface => {
+/**
+ * The `useStore()` composable allows loading and changing currently active store
+ *
+ * See the {@link UseStoreInterface} page for more information.
+ */
+export function useStore(): UseStoreInterface {
   const loading: Ref<boolean> = ref(false);
-  const error: Ref<UseStoreErrors> = ref({ load: null, change: null });
+  const error: Ref<UseStoreErrors> = ref({
+    load: null,
+    change: null,
+  });
   const configStore = useConfigStore();
-  const stores = computed(() => configStore.stores);
   const { app } = useContext();
 
   const load = async (customQuery = { availableStores: 'availableStores' }): Promise<void> => {
@@ -52,12 +62,13 @@ const useStore: UseStore = (): UseStoreInterface => {
   };
 
   return {
+    stores: computed(() => configStore.stores),
     load,
     change,
-    stores,
-    loading,
-    error,
+    loading: readonly(loading),
+    error: readonly(error),
   };
-};
+}
 
 export default useStore;
+export * from './useStore';

--- a/packages/theme/composables/useStore/useStore.ts
+++ b/packages/theme/composables/useStore/useStore.ts
@@ -1,21 +1,41 @@
-import { Ref } from '@nuxtjs/composition-api';
-import { StoreConfig, AvailableStoresQuery } from '~/modules/GraphQL/types';
+import type { Ref, DeepReadonly } from '@nuxtjs/composition-api';
+import type { StoreConfig } from '~/modules/GraphQL/types';
+import type { AvailableStores } from '~/composables/types';
 
-export interface UseStoreInterface {
-  change(store: StoreConfig): void;
-  load(customQuery?: { availableStores: string }): Promise<void>;
-  stores: Ref<AvailableStores>,
-  loading: Ref<boolean>,
-  error: Ref<UseStoreErrors>,
-}
-
-export interface UseStore {
-  (): UseStoreInterface;
-}
-
+/**
+ * Errors that occured in the `useStore` composable
+ */
 export interface UseStoreErrors {
   load: Error | null;
   change: Error | null;
 }
 
-export declare type AvailableStores = AvailableStoresQuery['availableStores'];
+/**
+ * Represents the data returned from and functions available in the `useStore()` composable.
+ */
+export interface UseStoreInterface {
+  /**
+   * Changes the current store and reloads the page
+   */
+  change(store: StoreConfig): void;
+
+  /**
+   * Fetches a list of available stores
+   */
+  load(customQuery?: { availableStores: string }): Promise<void>;
+
+  /**
+   * Main data object populated by the `load()` method
+   */
+  stores: Ref<AvailableStores>;
+
+  /**
+   * Indicates whether any of the methods is in progress
+   */
+  loading: DeepReadonly<Ref<boolean>>;
+
+  /**
+   * Contains errors from any of the composable methods
+   */
+  error: DeepReadonly<Ref<UseStoreErrors>>;
+}


### PR DESCRIPTION
This PR updates the `useStore` composable:

- [BREAKING CHANGE] wraps the `loading` and `error` objects with `readonly` so they cannot be manipulated outside of the composable,
- improves typing,
- adds a short description to all interfaces, types, and properties.