### PR TITLE
feat: add skeleton loaders in category navbar

### DIFF
--- a/packages/theme/components/SkeletonLoader/index.vue
+++ b/packages/theme/components/SkeletonLoader/index.vue
@@ -1,15 +1,13 @@
 <template>
-  <div>
+  <div
+    :class="componentClass"
+    :style="componentStyle"
+  >
     <slot v-if="!isLoading" />
-    <span
-      v-else
-      :class="componentClass"
-      :style="componentStyle"
-    />
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { computed, defineComponent } from '@nuxtjs/composition-api';
 
 export default defineComponent({

--- a/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
+++ b/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
@@ -15,7 +15,15 @@
     </SfButton>
     <div class="navbar__sort">
       <span class="navbar__label desktop-only">{{ $t('Sort by') }}:</span>
+      <SkeletonLoader
+        v-if="isLoading"
+        class="navbar__select navbar__select-skeleton"
+        height="26px"
+        width="185px"
+        margin="0"
+      />
       <SfSelect
+        v-else
         :value="sortBy.selected"
         class="navbar__select"
         @input="doChangeSorting"
@@ -32,11 +40,17 @@
     </div>
 
     <div class="navbar__counter">
-      <span class="navbar__label desktop-only">{{ $t('Products found') }}</span>
-      <span class="desktop-only">{{ pagination.totalItems }}</span>
-      <span class="navbar__label smartphone-only">{{ pagination.totalItems }} {{
-        $t('Items')
-      }}</span>
+      <span class="navbar__label desktop-only">{{ $t('Products found') }}: </span>
+      <SkeletonLoader
+        v-if="isLoading"
+        width="15px"
+        height="26px"
+        margin="0"
+      />
+      <span
+        v-else
+      >{{ pagination.totalItems }}</span>
+      <span class="navbar__label smartphone-only">&nbsp;{{ $t('Items') }}</span>
     </div>
 
     <div class="navbar__view">
@@ -73,9 +87,11 @@ import {
 import SvgImage from '~/components/General/SvgImage.vue';
 import { useUiHelpers, useUiState } from '~/composables';
 import { AgnosticPagination, AgnosticSort } from '~/composables/types';
+import SkeletonLoader from '~/components/SkeletonLoader/index.vue';
 
 export default defineComponent({
   components: {
+    SkeletonLoader,
     SvgImage,
     SfSelect,
     SfButton,
@@ -88,6 +104,10 @@ export default defineComponent({
     pagination: {
       type: Object as PropType<AgnosticPagination>,
       required: true,
+    },
+    isLoading: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(_, { emit }) {
@@ -197,7 +217,7 @@ export default defineComponent({
   }
 
   &__select {
-    --select-width: 220px;
+    --select-width: 185px;
     --select-padding: 0;
     --select-height: auto;
     --select-selected-padding: 0 var(--spacer-lg) 0 var(--spacer-2xs);
@@ -214,10 +234,6 @@ export default defineComponent({
 
     ::v-deep .sf-select__placeholder {
       --select-option-font-size: var(--font-size-sm);
-    }
-
-    @include for-mobile {
-      --select-width: 135px;
     }
   }
 

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -30,6 +30,7 @@
           v-if="isShowProducts"
           :sort-by="sortBy"
           :pagination="pagination"
+          :is-loading="$fetchState.pending"
           @reloadProducts="fetch"
         />
         <div class="products">


### PR DESCRIPTION
## Description
add skeleton loaders in category navbar

## How Has This Been Tested?

- Visit category page, execute any action eg. add filter
- Observe that skeletons are now masking loaded fields

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
