### PR TITLE
fix: category page - equal amount of product for a row

### DIFF
--- a/packages/theme/modules/catalog/category/components/views/CategoryProductGrid.vue
+++ b/packages/theme/modules/catalog/category/components/views/CategoryProductGrid.vue
@@ -100,7 +100,7 @@ export default defineComponent({
   flex: 1 1 50%;
 
   @include for-desktop {
-    flex: 1 1 25%;
+    flex: 1 1 23%;
     --product-card-title-font-weight: var(--font-weight--normal);
     --product-card-add-button-bottom: var(--spacer-base);
     --product-card-title-margin: var(--spacer-sm) 0 0 0;


### PR DESCRIPTION
## Description
fix: category page - an equal amount of product for a row

## Screenshots (if appropriate):
![Screenshot 2022-05-16 at 14 57 21](https://user-images.githubusercontent.com/16045377/168597792-ce62b7cb-ea2a-4de3-bdad-fafbdb101788.png)

## Related issues
#998 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
