### PR TITLE
fix: grouped product special price calculation

### DIFF
--- a/packages/theme/modules/catalog/pricing/getGroupedProductPriceCommand.ts
+++ b/packages/theme/modules/catalog/pricing/getGroupedProductPriceCommand.ts
@@ -5,7 +5,7 @@ export function getGroupedProductPriceCommand(product: GroupedProduct): number {
   const evalProductPrice = (p: ProductInterface) => {
     const { regular, special } = getProductPrice(p);
 
-    return regular > special ? regular : special;
+    return regular > special && special !== null ? special : regular;
   };
 
   return product.items.reduce(

--- a/packages/theme/modules/catalog/product/components/product-types/grouped/GroupedProductSelector.vue
+++ b/packages/theme/modules/catalog/product/components/product-types/grouped/GroupedProductSelector.vue
@@ -115,9 +115,8 @@ export default defineComponent({
 
     watch(
       () => props.product,
-      (newValue) => {
-        const price = getGroupedProductPriceCommand(newValue);
-
+      (product) => {
+        const price = getGroupedProductPriceCommand(product);
         emit('update-price', price);
       },
       {


### PR DESCRIPTION
## Description
Actual behavior

The total price is calculated without including the special price of the first product - looks like the first product in the group is treated as a "normal" priced product.
Expected behavior

The total price is calculated correctly by using special prices associated with product.
Additional bug information

Reproduced with Chromium-based browsers (Chrome, Edge), Safari, and Firefox.


## How Has This Been Tested?
change grouped product options and observe if normal and special prices are calculated properly in the total result

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
