### PR TITLE
refactor: refactored useUrlResolver to use the route query

### DIFF
--- a/packages/api-client/src/api/index.ts
+++ b/packages/api-client/src/api/index.ts
@@ -60,5 +60,6 @@ export { default as updateCustomerAddress } from './updateCustomerAddress';
 export { default as updateCustomerEmail } from './updateCustomerEmail';
 export { default as upsellProduct } from './upsellProduct';
 export { default as urlResolver } from './urlResolver';
+export { default as route } from './route';
 export { default as wishlist } from './wishlist';
 export { default as wishlistItemsCount } from './wishlistItemsCount';

--- a/packages/api-client/src/api/route/index.ts
+++ b/packages/api-client/src/api/route/index.ts
@@ -15,11 +15,11 @@ export type RouteQuery<ROUTE_TYPE> = {
  * @param url the URL to be resolved
  * @param [customQuery] (optional) - custom GraphQL query that extends the default one
  */
-export default async function route<ROUTE_TYPE extends RoutableInterface>(
+export default async function route(
   context: Context,
   url: string,
   customQuery: CustomQuery = { route: 'route' },
-): Promise<ApolloQueryResult<RouteQuery<ROUTE_TYPE>>> {
+): Promise<ApolloQueryResult<RouteQuery<RoutableInterface>>> {
   const { route: routeGQL } = context.extendQuery(customQuery, {
     route: {
       query: routeQuery,
@@ -27,7 +27,7 @@ export default async function route<ROUTE_TYPE extends RoutableInterface>(
     },
   });
 
-  return context.client.query<RouteQuery<ROUTE_TYPE>, QueryRouteArgs>({
+  return context.client.query<RouteQuery<RoutableInterface>, QueryRouteArgs>({
     query: routeGQL.query,
     variables: routeGQL.variables,
   });

--- a/packages/api-client/src/api/route/index.ts
+++ b/packages/api-client/src/api/route/index.ts
@@ -1,0 +1,34 @@
+import type { ApolloQueryResult } from '@apollo/client/core';
+import type { CustomQuery } from '@vue-storefront/core';
+import type { QueryRouteArgs, RoutableInterface } from '../../types/GraphQL';
+import routeQuery from './route';
+import type { Context } from '../../types/context';
+
+export type RouteQuery<ROUTE_TYPE> = {
+  route: ROUTE_TYPE
+};
+
+/**
+ * Returns the canonical URL for a specified product, category, or CMS page
+ *
+ * @param context VSF Context
+ * @param url the URL to be resolved
+ * @param [customQuery] (optional) - custom GraphQL query that extends the default one
+ */
+export default async function route<ROUTE_TYPE extends RoutableInterface>(
+  context: Context,
+  url: string,
+  customQuery: CustomQuery = { route: 'route' },
+): Promise<ApolloQueryResult<RouteQuery<ROUTE_TYPE>>> {
+  const { route: routeGQL } = context.extendQuery(customQuery, {
+    route: {
+      query: routeQuery,
+      variables: { url },
+    },
+  });
+
+  return context.client.query<RouteQuery<ROUTE_TYPE>, QueryRouteArgs>({
+    query: routeGQL.query,
+    variables: routeGQL.variables,
+  });
+}

--- a/packages/api-client/src/api/route/route.ts
+++ b/packages/api-client/src/api/route/route.ts
@@ -1,0 +1,16 @@
+import gql from 'graphql-tag';
+
+/** GraphQL Query that fetches the resolver for received URL. */
+export default gql`
+  query route($url: String!) {
+    route(url: $url) {
+      relative_url
+      redirect_code
+      type
+      ... on CategoryTree {
+        uid
+        id
+      }
+    }
+  }
+`;

--- a/packages/api-client/src/api/urlResolver/index.ts
+++ b/packages/api-client/src/api/urlResolver/index.ts
@@ -10,6 +10,7 @@ import type { Context } from '../../types/context';
  * @param context VSF Context
  * @param url the URL to be resolved
  * @param [customQuery] (optional) - custom GraphQL query that extends the default one
+ * @deprecated - use route instead
  */
 export default async function urlResolver(
   context: Context,

--- a/packages/api-client/src/types/API.ts
+++ b/packages/api-client/src/types/API.ts
@@ -107,7 +107,7 @@ import {
   ChangeCustomerPasswordMutation,
   CreateCustomerAddressMutation,
   DownloadableProduct,
-  VirtualProduct, CustomerOrdersFilterInput,
+  VirtualProduct, CustomerOrdersFilterInput, RoutableInterface,
 } from './GraphQL';
 import { SetPaymentMethodOnCartInputs } from '../api/setPaymentMethodOnCart';
 import { CustomerProductReviewParams } from '../api/customerProductReview';
@@ -441,10 +441,10 @@ export interface MagentoApiMethods {
     customQuery?: CustomQuery
   ): Promise<ApolloQueryResult<UrlResolverQuery>>;
 
-  route<ROUTE_TYPE>(
+  route(
     url: string,
     customQuery?: CustomQuery
-  ): Promise<ApolloQueryResult<RouteQuery<ROUTE_TYPE>>>;
+  ): Promise<ApolloQueryResult<RouteQuery<RoutableInterface>>>;
 
   wishlist(
     searchParams: WishlistQueryVariables,

--- a/packages/api-client/src/types/API.ts
+++ b/packages/api-client/src/types/API.ts
@@ -112,6 +112,7 @@ import {
 import { SetPaymentMethodOnCartInputs } from '../api/setPaymentMethodOnCart';
 import { CustomerProductReviewParams } from '../api/customerProductReview';
 import { AddProductsToCartInput } from '../api/addProductsToCart';
+import type { RouteQuery } from '../api/route';
 
 export interface Product extends ProductInterface, ConfigurableProduct, Omit<BundleProduct, 'items'>, Omit<GroupedProduct, 'items'>, Omit<DownloadableProduct, 'items'>, Omit<VirtualProduct, 'items'> {
 }
@@ -439,6 +440,11 @@ export interface MagentoApiMethods {
     url: string,
     customQuery?: CustomQuery
   ): Promise<ApolloQueryResult<UrlResolverQuery>>;
+
+  route<ROUTE_TYPE>(
+    url: string,
+    customQuery?: CustomQuery
+  ): Promise<ApolloQueryResult<RouteQuery<ROUTE_TYPE>>>;
 
   wishlist(
     searchParams: WishlistQueryVariables,

--- a/packages/theme/composables/useUrlResolver/UseUrlResolver.ts
+++ b/packages/theme/composables/useUrlResolver/UseUrlResolver.ts
@@ -1,5 +1,5 @@
 import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
-import { RoutableInterface } from '@vue-storefront/magento-api';
+import { RoutableInterface } from '~/modules/GraphQL/types';
 
 /**
  * Errors that occured in the {@link UseUrlResolverErrors|UseUrlResolverErrors()} composable
@@ -19,7 +19,7 @@ export interface UseUrlResolverErrors {
  * `ROUTE_TYPE` is a generic type and can be one of: `CategoryTree`, `CmsPage`, `VirtualProduct`, `SimpleProduct`,
  * `DownloadableProduct`, `BundleProduct`, `GroupedProduct` or `ConfigurableProduct`
  */
-export interface UseUrlResolverInterface<ROUTE_TYPE extends RoutableInterface> {
+export interface UseUrlResolverInterface {
   /**
    * The current route path
    */
@@ -38,5 +38,5 @@ export interface UseUrlResolverInterface<ROUTE_TYPE extends RoutableInterface> {
   /**
    * Searches the resolver for current route URL
    */
-  search(): Promise<ROUTE_TYPE>;
+  search(): Promise<RoutableInterface>;
 }

--- a/packages/theme/composables/useUrlResolver/UseUrlResolver.ts
+++ b/packages/theme/composables/useUrlResolver/UseUrlResolver.ts
@@ -1,5 +1,5 @@
 import type { DeepReadonly, Ref } from '@nuxtjs/composition-api';
-import type { EntityUrl } from '~/modules/GraphQL/types';
+import { RoutableInterface } from '@vue-storefront/magento-api';
 
 /**
  * Errors that occured in the {@link UseUrlResolverErrors|UseUrlResolverErrors()} composable
@@ -12,9 +12,14 @@ export interface UseUrlResolverErrors {
 }
 
 /**
- * Data and methods returned from the {@link useUrlResolver|useUrlResolver()} composable
+ * Data and methods returned from the {@link useUrlResolver|useUrlResolver()} composable.
+ *
+ * @remarks
+ *
+ * `ROUTE_TYPE` is a generic type and can be one of: `CategoryTree`, `CmsPage`, `VirtualProduct`, `SimpleProduct`,
+ * `DownloadableProduct`, `BundleProduct`, `GroupedProduct` or `ConfigurableProduct`
  */
-export interface UseUrlResolverInterface {
+export interface UseUrlResolverInterface<ROUTE_TYPE extends RoutableInterface> {
   /**
    * The current route path
    */
@@ -33,5 +38,5 @@ export interface UseUrlResolverInterface {
   /**
    * Searches the resolver for current route URL
    */
-  search(): Promise<EntityUrl | {}>;
+  search(): Promise<ROUTE_TYPE>;
 }

--- a/packages/theme/composables/useUrlResolver/index.ts
+++ b/packages/theme/composables/useUrlResolver/index.ts
@@ -4,7 +4,7 @@ import {
   useRoute,
   useContext,
 } from '@nuxtjs/composition-api';
-import type { RoutableInterface } from '@vue-storefront/magento-api';
+import { RoutableInterface } from '~/modules/GraphQL/types';
 import { Logger } from '~/helpers/logger';
 import type { UseUrlResolverErrors, UseUrlResolverInterface } from '~/composables';
 
@@ -14,7 +14,7 @@ import type { UseUrlResolverErrors, UseUrlResolverInterface } from '~/composable
  *
  * See the {@link UseUrlResolverInterface} for a list of methods and values available in this composable.
  */
-export function useUrlResolver<ROUTE_TYPE extends RoutableInterface>(): UseUrlResolverInterface<ROUTE_TYPE> {
+export function useUrlResolver(): UseUrlResolverInterface {
   const route = useRoute();
   const { error: nuxtError, app } = useContext();
   const context = app.$vsf;
@@ -24,16 +24,15 @@ export function useUrlResolver<ROUTE_TYPE extends RoutableInterface>(): UseUrlRe
     search: null,
   });
 
-  const search = async (): Promise<ROUTE_TYPE> => {
+  const search = async (): Promise<RoutableInterface | null> => {
     loading.value = true;
-    let results: ROUTE_TYPE | null = null;
+    let results: RoutableInterface | null = null;
 
     try {
       const clearUrl = path.replace(/[a-z]+\/[cp|]\//gi, '');
       Logger.debug('[Magento] Find information based on URL', { clearUrl });
       const { data } = await context.$magento.api.route(clearUrl);
-      // @ts-ignore
-      results = data.route;
+      results = data?.route ?? null;
 
       if (!results) nuxtError({ statusCode: 404 });
 

--- a/packages/theme/composables/useUrlResolver/index.ts
+++ b/packages/theme/composables/useUrlResolver/index.ts
@@ -4,8 +4,8 @@ import {
   useRoute,
   useContext,
 } from '@nuxtjs/composition-api';
+import type { RoutableInterface } from '@vue-storefront/magento-api';
 import { Logger } from '~/helpers/logger';
-import type { EntityUrl } from '~/modules/GraphQL/types';
 import type { UseUrlResolverErrors, UseUrlResolverInterface } from '~/composables';
 
 /**
@@ -14,7 +14,7 @@ import type { UseUrlResolverErrors, UseUrlResolverInterface } from '~/composable
  *
  * See the {@link UseUrlResolverInterface} for a list of methods and values available in this composable.
  */
-export function useUrlResolver(): UseUrlResolverInterface {
+export function useUrlResolver<ROUTE_TYPE extends RoutableInterface>(): UseUrlResolverInterface<ROUTE_TYPE> {
   const route = useRoute();
   const { error: nuxtError, app } = useContext();
   const context = app.$vsf;
@@ -24,15 +24,16 @@ export function useUrlResolver(): UseUrlResolverInterface {
     search: null,
   });
 
-  const search = async (): Promise<EntityUrl | {}> => {
+  const search = async (): Promise<ROUTE_TYPE> => {
     loading.value = true;
-    let results: EntityUrl = {};
+    let results: ROUTE_TYPE | null = null;
 
     try {
       const clearUrl = path.replace(/[a-z]+\/[cp|]\//gi, '');
       Logger.debug('[Magento] Find information based on URL', { clearUrl });
-      const { data } = await context.$magento.api.urlResolver(clearUrl);
-      results = data.urlResolver;
+      const { data } = await context.$magento.api.route(clearUrl);
+      // @ts-ignore
+      results = data.route;
 
       if (!results) nuxtError({ statusCode: 404 });
 

--- a/packages/theme/modules/GraphQL/CategoryTreeRouteTypeguard.ts
+++ b/packages/theme/modules/GraphQL/CategoryTreeRouteTypeguard.ts
@@ -1,0 +1,3 @@
+import { CategoryTree, RoutableInterface } from '~/modules/GraphQL/types';
+
+export const isCategoryTreeRoute = (object: RoutableInterface): object is CategoryTree => (object as CategoryTree).uid !== undefined;

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -127,6 +127,7 @@ import facetGetters from '~/modules/catalog/category/getters/facetGetters';
 
 import CategoryNavbar from '~/modules/catalog/category/components/navbar/CategoryNavbar.vue';
 import CategoryBreadcrumbs from '~/modules/catalog/category/components/breadcrumbs/CategoryBreadcrumbs.vue';
+import { isCategoryTreeRoute } from '~/modules/GraphQL/CategoryTreeRouteTypeguard';
 
 import type { ProductInterface, CategoryTree } from '~/modules/GraphQL/types';
 import type { SortingModel } from '~/modules/catalog/category/composables/useFacet/sortingOptions';
@@ -162,7 +163,7 @@ export default defineComponent({
 
     const productContainerElement = ref<HTMLElement | null>(null);
 
-    const { search: resolveUrl } = useUrlResolver<CategoryTree>();
+    const { search: resolveUrl } = useUrlResolver();
     const {
       toggleFilterSidebar,
       changeToCategoryListView,
@@ -189,7 +190,8 @@ export default defineComponent({
     const routeData = ref<CategoryTree | null>(null);
 
     const { fetch } = useFetch(async () => {
-      routeData.value = await resolveUrl();
+      const resolvedUrl = await resolveUrl();
+      if (isCategoryTreeRoute(resolvedUrl)) routeData.value = resolvedUrl;
 
       const categoryId = routeData.value?.id;
 

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -128,7 +128,7 @@ import facetGetters from '~/modules/catalog/category/getters/facetGetters';
 import CategoryNavbar from '~/modules/catalog/category/components/navbar/CategoryNavbar.vue';
 import CategoryBreadcrumbs from '~/modules/catalog/category/components/breadcrumbs/CategoryBreadcrumbs.vue';
 
-import type { EntityUrl, ProductInterface } from '~/modules/GraphQL/types';
+import type { ProductInterface, CategoryTree } from '~/modules/GraphQL/types';
 import type { SortingModel } from '~/modules/catalog/category/composables/useFacet/sortingOptions';
 import type { Pagination } from '~/composables/types';
 import type { Product } from '~/modules/catalog/product/types';
@@ -162,7 +162,7 @@ export default defineComponent({
 
     const productContainerElement = ref<HTMLElement | null>(null);
 
-    const { search: resolveUrl } = useUrlResolver();
+    const { search: resolveUrl } = useUrlResolver<CategoryTree>();
     const {
       toggleFilterSidebar,
       changeToCategoryListView,
@@ -186,7 +186,7 @@ export default defineComponent({
 
     const { activeCategory } = useTraverseCategory();
     const activeCategoryName = computed(() => activeCategory.value?.name ?? '');
-    const routeData = ref<EntityUrl>({});
+    const routeData = ref<CategoryTree | null>(null);
 
     const { fetch } = useFetch(async () => {
       routeData.value = await resolveUrl();
@@ -194,7 +194,7 @@ export default defineComponent({
       const categoryId = routeData.value?.id;
 
       const [content] = await Promise.all([
-        getContentData(routeData.value?.entity_uid),
+        getContentData(routeData.value?.uid),
         search({ ...uiHelpers.getFacetsFromURL(), categoryId }),
       ]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
THe urlResolver Magento query is deprecated on Magento API side. This PR:
- adds a new route query to the VSF API Client
- updates the useUrlResolver composable to use the new route query instead of depracated urlResolver query.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Refactorization

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
