### PR TITLE
fix: m2-606. category page filters are take off after using pagination

### DIFF
--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -26,14 +26,14 @@ function reduceFilters(query: QueryParams) {
 export function useUiHelpers(): UseUiHelpersInterface {
   const route = useRoute();
   const router = useRouter();
-  let { query } = route.value;
+  let { query: routerQuery } = route.value;
 
   const resolveQuery = (): QueryParams => {
     if (typeof window !== 'undefined') {
-      query = router.resolve((window.location.pathname + window.location.search).slice(1)).route.query;
+      routerQuery = router.resolve((window.location.pathname + window.location.search).slice(1)).route.query;
     }
 
-    return query;
+    return routerQuery;
   };
 
   const getFiltersDataFromUrl = (onlyFilters = false): FilterParams => {
@@ -82,7 +82,7 @@ export function useUiHelpers(): UseUiHelpersInterface {
    */
   const changeSorting = async (sort: string, forcePush = true): Promise<void> => {
     if (forcePush) {
-      await router.push({ query: { ...query, sort } });
+      await router.push({ query: { ...routerQuery, sort } });
     } else {
       const routeData = router.resolve({
         query: {
@@ -101,20 +101,15 @@ export function useUiHelpers(): UseUiHelpersInterface {
    * @param forcePush
    */
   const changeFilters = async (filters: FilterParams, forcePush = true): Promise<void> => {
+    const query = {
+      ...getFiltersDataFromUrl(false),
+      ...filters,
+    };
+
     if (forcePush) {
-      await router.push({
-        query: {
-          ...getFiltersDataFromUrl(false),
-          ...filters,
-        },
-      });
+      await router.push({ query });
     } else {
-      const routeData = router.resolve({
-        query: {
-          ...getFiltersDataFromUrl(),
-          ...filters,
-        },
-      });
+      const routeData = router.resolve({ query });
       window.history.pushState({}, null, routeData.href);
     }
   };
@@ -139,20 +134,29 @@ export function useUiHelpers(): UseUiHelpersInterface {
    * @param forcePush
    */
   const changeItemsPerPage = async (itemsPerPage: number, forcePush = true): Promise<void> => {
+    const query = {
+      ...getFiltersDataFromUrl(false),
+      itemsPerPage: itemsPerPage.toString(10),
+    };
+
     if (forcePush) {
-      await router.push({
-        query: {
-          ...getFiltersDataFromUrl(false),
-          itemsPerPage: itemsPerPage.toString(10),
-        },
-      });
+      await router.push({ query });
     } else {
-      const routeData = router.resolve({
-        query: {
-          ...getFiltersDataFromUrl(),
-          itemsPerPage: itemsPerPage.toString(10),
-        },
-      });
+      const routeData = router.resolve({ query });
+      window.history.pushState({}, null, routeData.href);
+    }
+  };
+
+  const changePage = async (page: number, forcePush = true): Promise<void> => {
+    const query = {
+      ...getFiltersDataFromUrl(false),
+      page: page.toString(),
+    };
+
+    if (forcePush) {
+      await router.push({ query });
+    } else {
+      const routeData = router.resolve({ query });
       window.history.pushState({}, null, routeData.href);
     }
   };
@@ -182,6 +186,7 @@ export function useUiHelpers(): UseUiHelpersInterface {
     isFacetCheckbox,
     isFacetColor,
     setTermForUrl,
+    changePage,
   };
 }
 

--- a/packages/theme/composables/useUiHelpers/useUiHelpers.ts
+++ b/packages/theme/composables/useUiHelpers/useUiHelpers.ts
@@ -40,6 +40,13 @@ export interface UseUiHelpersInterface {
    */
   clearFilters(forcePush?: boolean): Promise<void>;
 
+  /**
+   * Updates current URL with a page as a query/search param.
+   *
+   * It forces the navigation to updated URL when `forcePush` is `true`.
+   */
+  changePage(page: number, forcePush?: boolean): Promise<void>;
+
   /** Gets route link for received category. */
   getCatLink(category: CategoryTree): string;
 
@@ -59,4 +66,5 @@ export interface UseUiHelpersInterface {
    * navigates to it.
    */
   setTermForUrl(term?: string): Promise<void>;
+
 }

--- a/packages/theme/modules/catalog/category/components/pagination/CategoryPagination.vue
+++ b/packages/theme/modules/catalog/category/components/pagination/CategoryPagination.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import { defineComponent } from '@nuxtjs/composition-api';
+import { SfButton, SfPagination, SfImage } from '@storefront-ui/vue';
+
+const ExtendedSfPagination = {
+  ...SfPagination,
+};
+
+export default defineComponent({
+  name: 'CategoryPagination',
+  components: {
+    SfButton,
+    SfImage,
+  },
+  extends: ExtendedSfPagination,
+  computed: {
+    /**
+     * On the category page we do not want to reload whole page when pagination changes
+     */
+    hasRouter() {
+      return false;
+    },
+  },
+});
+</script>

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -53,18 +53,18 @@
             @click:wishlist="addItemToWishlist"
             @click:add-to-cart="addItemToCart"
           />
-
           <div
             v-if="!$fetchState.pending"
             class="products__display-opt"
           >
             <LazyHydrate on-interaction>
-              <SfPagination
+              <CategoryPagination
                 v-show="pagination.totalPages > 1"
                 :current="pagination.currentPage"
                 :total="pagination.totalPages"
                 :visible="5"
                 class="products__pagination"
+                @click="goToPage($event)"
               />
             </LazyHydrate>
 
@@ -102,7 +102,6 @@
 <script lang="ts">
 import LazyHydrate from 'vue-lazy-hydration';
 import {
-  SfPagination,
   SfSelect,
   SfHeading,
 } from '@storefront-ui/vue';
@@ -111,6 +110,7 @@ import {
   defineComponent, onMounted, ref, ssrRef, useFetch,
 } from '@nuxtjs/composition-api';
 import { CacheTagPrefix, useCache } from '@vue-storefront/cache';
+import CategoryPagination from '~/modules/catalog/category/components/pagination/CategoryPagination.vue';
 import {
   useFacet,
   useUiHelpers,
@@ -136,6 +136,7 @@ import type { Product } from '~/modules/catalog/product/types';
 export default defineComponent({
   name: 'CategoryPage',
   components: {
+    CategoryPagination,
     CategoryEmptyResults: () => import('~/modules/catalog/category/components/CategoryEmptyResults.vue'),
     CategoryFilters: () => import('~/modules/catalog/category/components/filters/CategoryFilters.vue'),
     CmsContent: () => import('~/modules/catalog/category/components/cms/CmsContent.vue'),
@@ -143,7 +144,6 @@ export default defineComponent({
     CategoryProductList: () => import('~/modules/catalog/category/components/views/CategoryProductList.vue'),
     CategoryNavbar,
     CategoryBreadcrumbs,
-    SfPagination,
     SfSelect,
     LazyHydrate,
     SfHeading,
@@ -239,6 +239,11 @@ export default defineComponent({
       productContainerElement.value.scrollIntoView();
     };
 
+    const goToPage = (page: number) => {
+      uiHelpers.changePage(page, false);
+      fetch();
+    };
+
     return {
       isPriceLoaded,
       ...uiHelpers,
@@ -260,6 +265,7 @@ export default defineComponent({
       doChangeItemsPerPage,
       productContainerElement,
       onReloadProducts,
+      goToPage,
     };
   },
 });


### PR DESCRIPTION
## Description
Filters are not taken off after when using pagination on the category page.

## Motivation and Context
Bugfix

## How Has This Been Tested?
1. Go to Category Page (can be main or for given product type) - i. e. https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io/default/c/women/tops-women/jackets-women.html
2. Setup filter/category which should return > 10 products - i. e. Solid.
3. Hit Apply filters.
4. Switch to the second page of listed products.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
