### PR TITLE
fix: m2-726. category page header invalid title

### DIFF
--- a/packages/theme/modules/catalog/category/helpers/__tests__/findActiveCategory.spec.ts
+++ b/packages/theme/modules/catalog/category/helpers/__tests__/findActiveCategory.spec.ts
@@ -20,6 +20,22 @@ describe('Find active category', () => {
     expect(result).toMatchObject(sharedMatch);
   });
 
+  it('find category node by default key with overlapping keys value (women, men)', () => {
+    const result = findActiveCategory(categoryTreeData[0], 'men');
+
+    expect(result).toMatchObject({
+      is_anchor: 0,
+      name: 'Men',
+      position: 3,
+      product_count: 0,
+      uid: 'MTE=',
+      url_path: 'men',
+      url_suffix: '.html',
+      include_in_menu: 1,
+      redirect_code: 301,
+    });
+  });
+
   it('find category node by custom key', () => {
     const result = findActiveCategory(categoryTreeData[0], 'MjA=', 'uid');
 

--- a/packages/theme/modules/catalog/category/helpers/findActiveCategory.ts
+++ b/packages/theme/modules/catalog/category/helpers/findActiveCategory.ts
@@ -12,7 +12,8 @@ import { CategoryTree } from '~/modules/GraphQL/types';
  */
 export function findActiveCategory(categoryTree: CategoryTree, toFind: string, findBy: keyof CategoryTree = 'url_path'): CategoryTree | null {
   const categories = categoryTree?.children;
+
   return categories
-    ? findDeep(categories, (value: string, key: string) => key === findBy && value.includes(toFind))?.parent ?? null
+    ? findDeep(categories, (value: string, key: string) => key === findBy && value === toFind)?.parent ?? null
     : null;
 }


### PR DESCRIPTION
## Description
Fix active category resolving in `useTraverseCategory`

## How Has This Been Tested?
Open "Men" category - https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io/default/c/men.html

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
