### PR TITLE
fix: removed filters skeleton on mobile devices

### DIFF
--- a/packages/theme/modules/catalog/category/components/filters/CategoryFilters.vue
+++ b/packages/theme/modules/catalog/category/components/filters/CategoryFilters.vue
@@ -10,6 +10,7 @@
       <div
         v-for="n in 3"
         :key="n"
+        class="desktop-only"
       >
         <SkeletonLoader
           class="filters__title sf-heading--left sf-heading"


### PR DESCRIPTION
### Before 
before this change on the category page, there were filters loading skeleton on mobile devices, but on mobile devices, filters can be visible only in overlay

### After
After this change loader skeleton for filters on the category page is not visible anymore on mobile devices.