### PR TITLE
fix: m2-593. my account password change toast fix

### DIFF
--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -277,4 +277,6 @@ export default {
   "From": "Aus",
   "To": "Zu",
   "Your customization": "Ihre Anpassung",
+  "Passwords don't match":"Passwörter stimmen nicht überein",
+  "The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)":"Das Passwort muss mindestens 8 Zeichen lang sein und muss mindestens enthalten: 1 Groß- oder Kleinbuchstabe, 1 Ziffer oder ein Sonderzeichen (z. B. , . _ & ? usw.)"
 };

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -275,4 +275,6 @@ export default {
   "From": "From",
   "To": "To",
   "Your customization": "Your customization",
+  "Passwords don't match":"Passwords don't match",
+  "The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)":"The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)"
 };

--- a/packages/theme/modules/customer/composables/useUser/index.ts
+++ b/packages/theme/modules/customer/composables/useUser/index.ts
@@ -280,14 +280,17 @@ export function useUser(): UseUserInterface {
         customQuery: params.customQuery,
       });
 
+      let joinedErrors = null;
+
       if (errors) {
-        Logger.error(errors.map((e) => e.message).join(','));
+        joinedErrors = errors.map((e) => e.message).join(',');
+        Logger.error(joinedErrors);
       }
 
       Logger.debug('[Result] ', { data });
 
       customerStore.user = data?.changeCustomerPassword;
-      error.value.changePassword = null;
+      error.value.changePassword = joinedErrors;
     } catch (err) {
       error.value.changePassword = err;
       Logger.error('useUser/changePassword', err);


### PR DESCRIPTION
## Description
Toast with an error message should show up instead of success toast.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. log in to your account.
2. Hit the Account icon I top navigation.
3. Go to password change.
4. Input the wrong current password.
5. Input a new password.
6. Hit Update Password.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
