### PR TITLE
fix: m2-705. fixed adding grouped product to cart from catalog

### DIFF
--- a/packages/theme/helpers/cart/addToCart.ts
+++ b/packages/theme/helpers/cart/addToCart.ts
@@ -25,6 +25,7 @@ export const useAddToCart = () => {
         break;
       case 'BundleProduct':
       case 'ConfigurableProduct':
+      case 'GroupedProduct':
         const sku = productGetters.getProductSku(product);
         const slug = productGetters.getSlug(product).replace(/^\//, ''); // remove leading slash from getSlug
 


### PR DESCRIPTION
From now when the user adds to the cart grouped product on the category page, VSF will redirect to the product page and add the possibility to select grouped product options.