### PR TITLE
fix: move user to first page of products after applying filters

### DIFF
--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -236,14 +236,14 @@ export default defineComponent({
       fetch();
     };
 
-    const onReloadProducts = () => {
-      fetch();
-      productContainerElement.value.scrollIntoView();
-    };
-
     const goToPage = (page: number) => {
       uiHelpers.changePage(page, false);
       fetch();
+    };
+
+    const onReloadProducts = () => {
+      goToPage(0);
+      productContainerElement.value.scrollIntoView();
     };
 
     return {


### PR DESCRIPTION
before this commit, the page number remained unchanged after changing filters

this was as problem in the scenario where:
1. open the category Women - it has 8 pages by default
2. go to page 8
3. apply some filter - eg. select "Capri" in the Material section
4. the `yarn dev` console where nuxt is running will report errors like
"currentPage value 8 specified is greater than the X page(s) available"

you can't know how many pages a filter will return so always returning
to first page makes sense

this also works ok if no products are returned<!--- Provide a general summary of your changes in the Title above -->

