### PR TITLE
fix:  cart, checkout - size and colour values are wrongly dispayed

### DIFF
--- a/packages/theme/modules/checkout/composables/useCart/commands/addItemCommand.ts
+++ b/packages/theme/modules/checkout/composables/useCart/commands/addItemCommand.ts
@@ -61,13 +61,16 @@ export const addItemCommand = {
           .addProductsToCart
           .cart as unknown as Cart;
       case 'ConfigurableProduct':
+        const selectedOptions = product.configurable_product_options_selection.options_available_for_selection
+          .flatMap((attr) => attr.option_value_uids);
+
         const configurableCartInput: AddProductsToCartInput = {
           cartId,
           cartItems: [
             {
-              parent_sku: product.sku,
               quantity,
-              sku: product.configurable_product_options_selection?.variant?.sku || '',
+              sku: product.sku,
+              selected_options: selectedOptions,
             },
           ],
         };


### PR DESCRIPTION
### Before
Before this PR, configurable product's selected options were not displayed on cart and checkout
![Screenshot 2022-06-23 at 16 04 58](https://user-images.githubusercontent.com/11998249/175318693-0ff33e21-1c88-4017-a880-b6161f6debc8.png)


### After
After this PR, configurable product's selected options are displayed in the mini cart and checkout
![Screenshot 2022-06-23 at 16 04 42](https://user-images.githubusercontent.com/11998249/175318645-7fc0520d-34c1-4892-8d48-38f6e18b13a0.png)

M2-860