### PR TITLE
fix(category): fix various rwd issues on category mobile view

### DIFF
--- a/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
+++ b/packages/theme/modules/catalog/category/components/navbar/CategoryNavbar.vue
@@ -139,7 +139,7 @@ export default defineComponent({
   align-content: center;
   border: 1px solid var(--c-light);
   border-width: 0 0 1px 0;
-  padding: var(--spacer-sm);
+  padding: var(--spacer-sm) var(--spacer-xs);;
 
   @include for-desktop {
     border-width: 1px 0 1px 0;
@@ -216,7 +216,6 @@ export default defineComponent({
   }
 
   &__select {
-    --select-width: 185px;
     --select-padding: 0;
     --select-height: auto;
     --select-selected-padding: 0 var(--spacer-lg) 0 var(--spacer-2xs);
@@ -250,6 +249,11 @@ export default defineComponent({
     order: 1;
     display: flex;
     align-items: center;
+
+    margin: {
+      left: var(--spacer-xs);
+      right: var(--spacer-xs);
+    }
     @include for-desktop {
       margin: auto 0 auto auto;
       order: 0;

--- a/packages/theme/modules/catalog/category/components/views/CategoryProductGrid.vue
+++ b/packages/theme/modules/catalog/category/components/views/CategoryProductGrid.vue
@@ -90,16 +90,15 @@ export default defineComponent({
   }
 }
 .card {
-  --product-card-title-margin: var(--spacer-base) 0 0 0;
   --product-card-title-font-weight: var(--font-weight--medium);
   --product-card-title-margin: var(--spacer-xs) 0 0 0;
-  flex: 1 1 50%;
+  flex: 1 1 100%;
 
   @include for-desktop {
-    flex: 1 1 23%;
+    --product-card-max-width: 25%;
     --product-card-title-font-weight: var(--font-weight--normal);
-    --product-card-add-button-bottom: var(--spacer-base);
     --product-card-title-margin: var(--spacer-sm) 0 0 0;
+    --product-card-add-button-bottom: var(--spacer-base);
   }
 }
 

--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -308,10 +308,12 @@ export default defineComponent({
 
 .main {
   &.section {
-    padding: var(--spacer-xs);
+    padding: 0;
 
-    @include for-desktop {
-      padding: 0;
+    @include for-mobile {
+      $padding: var(--spacer-xs);
+      padding: $padding;
+      width: calc(100% - 2 * $padding);
     }
   }
 }


### PR DESCRIPTION
1. Fix last element in first row sometimes being larger than other items
<img width="876" alt="image" src="https://user-images.githubusercontent.com/5359825/175536458-ffae3bc0-b4ee-4b50-ab1c-ac164b09af93.png">
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/5359825/175536801-76308fac-1e1b-48e3-8975-357683f204f5.png">



2. Fix "Filters" button being offscreen on a 320px wide viewport
<img width="394" alt="image" src="https://user-images.githubusercontent.com/5359825/175536715-ae44766a-b78d-48c9-adaa-236e266c5cd9.png">

<img width="395" alt="image" src="https://user-images.githubusercontent.com/5359825/175536670-f68d2eb9-0c2b-4986-90e7-d412abedbeb3.png">

3. Also fix product category sometimes being wider than the viewport iteslf
<img width="397" alt="image" src="https://user-images.githubusercontent.com/5359825/175536933-c9ffc3a6-f500-49a1-a91b-ad25ac714fb9.png">
<img width="486" alt="image" src="https://user-images.githubusercontent.com/5359825/175537035-909c7039-2031-467e-90b5-9959df85a8a9.png">

