### PR TITLE
fix: unify login/register notifications and error handling

### DIFF
--- a/packages/theme/modules/checkout/pages/Checkout/UserAccount.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/UserAccount.vue
@@ -147,9 +147,7 @@ import {
   required, min, email,
 } from 'vee-validate/dist/rules';
 import { ValidationProvider, ValidationObserver, extend } from 'vee-validate';
-import {
-  useUiNotification, useGuestUser,
-} from '~/composables';
+import { useGuestUser } from '~/composables';
 import useCart from '~/modules/checkout/composables/useCart';
 import { useUser } from '~/modules/customer/composables/useUser';
 import { getItem, mergeItem } from '~/helpers/asyncLocalStorage';
@@ -207,8 +205,6 @@ export default defineComponent({
       isAuthenticated,
       error: errorUser,
     } = useUser();
-
-    const { send: sendNotification } = useUiNotification();
 
     const isFormSubmitted = ref(false);
     const createUserAccount = ref(false);
@@ -270,16 +266,7 @@ export default defineComponent({
         });
       }
 
-      if (anyError.value) {
-        sendNotification({
-          id: Symbol('user_form_error'),
-          message: app.i18n.t(anyError.value.message) as string,
-          type: 'danger',
-          icon: 'error',
-          persist: false,
-          title: 'Error',
-        });
-      } else {
+      if (!anyError.value) {
         await mergeItem('checkout', { 'user-account': form.value });
         await router.push(app.localeRoute({ name: 'shipping' }));
         reset();

--- a/packages/theme/modules/customer/components/LoginModal/LoginModal.vue
+++ b/packages/theme/modules/customer/components/LoginModal/LoginModal.vue
@@ -26,11 +26,7 @@
           :form="loginForm"
           @submit="form => onLoginFormSubmit(form)"
           @change-form="currentlyDisplayedForm = $event"
-        >
-          <template #error>
-            {{ userError.login && userError.login.message }}
-          </template>
-        </LoginForm>
+        />
         <RegisterForm
           v-else-if="currentlyDisplayedForm === 'register'"
           data-testid="register-form"
@@ -39,11 +35,7 @@
           :form="registerForm"
           @submit="form => onRegisterFormSubmit(form)"
           @change-form="currentlyDisplayedForm = $event"
-        >
-          <template #error>
-            {{ userError.register && userError.register.message }}
-          </template>
-        </RegisterForm>
+        />
         <ForgotPasswordForm
           v-else-if="currentlyDisplayedForm === 'forgotPassword'"
           data-testid="forgot-password-form"

--- a/packages/theme/modules/customer/components/LoginModal/__tests__/LoginModal.spec.ts
+++ b/packages/theme/modules/customer/components/LoginModal/__tests__/LoginModal.spec.ts
@@ -63,23 +63,6 @@ describe('LoginModal', () => {
     expect(useUserMock.login).toHaveBeenCalled();
   });
 
-  it('displays error message if login fails', async () => {
-    const useUserMockWithError = {
-      login: jest.fn(),
-      register: jest.fn(),
-      loading: false,
-      error: { login: { message: 'error:login' } },
-    };
-    (useUser as jest.Mock).mockReturnValueOnce(useUserMockWithError);
-    const { getByText } = render(LoginModal, {
-      localVue,
-      pinia: createTestingPinia(),
-    });
-    await waitFor(() => {
-      getByText('error:login');
-    });
-  });
-
   it('sends register form', async () => {
     const { getByTestId } = render(LoginModal, {
       localVue,
@@ -102,27 +85,6 @@ describe('LoginModal', () => {
 
     await waitFor(() => {
       expect(useUserMock.register).toHaveBeenCalled();
-    });
-  });
-
-  it('displays error message if register fails', async () => {
-    const useUserMockWithError = {
-      login: jest.fn(),
-      register: jest.fn(),
-      loading: false,
-      error: { register: { message: 'error:register' } },
-    };
-    (useUser as jest.Mock).mockReturnValueOnce(useUserMockWithError);
-    const { getByText, getByTestId } = render(LoginModal, {
-      localVue,
-      pinia: createTestingPinia(),
-    });
-
-    await waitFor(() => {
-      (getByTestId('login-form') as HTMLElementWithVue).__vue__.$emit('change-form', 'register' as FormName);
-    });
-    await waitFor(() => {
-      getByText('error:register');
     });
   });
 


### PR DESCRIPTION
Before this commit, useUser().register error path used useUiNotification().sendNotification,
but useUser().login's error path did not. UserAccount.vue used sendNotification
aswell on its own side.

So when login() errored (bad password etc.) the useUser().login didn't
send notifications, but UserAccount.vue - further down the pipeline - did.

The contrary happened in register() - both UserAccount.vue and
register() sent notifications.

So I had to make a decision - either add sendNotification to
useUser().login the same way as in register, AND remove the
UserAccount.vue notifications

or

remove notifications from the composable and just handle it in
UserAccount.vue itself.

We decided on option 1 with Marcin.

M2-753