### PR TITLE
refactor:  user addresses styling

### DIFF
--- a/packages/theme/modules/checkout/components/UserBillingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserBillingAddresses.vue
@@ -2,14 +2,14 @@
   <div>
     <SfAddressPicker
       :selected="`${selectedAddress}`"
-      class="billing__addresses"
+      class="addresses"
       @change="setCurrentAddress($event)"
     >
       <SfAddress
         v-for="billingAddress in addressesWithCountryName"
         :key="userBillingGetters.getId(billingAddress)"
         :name="`${userBillingGetters.getId(billingAddress)}`"
-        class="billing__address"
+        class="address"
       >
         <UserAddressDetails :address="billingAddress">
           <template #country>
@@ -22,7 +22,7 @@
       :selected="value"
       name="setAsDefault"
       label="Use this address as my default one."
-      class="billing__setAsDefault"
+      class="setAsDefault"
       @change="$emit('input', $event)"
     />
     <hr class="sf-divider">
@@ -99,31 +99,5 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.billing {
-  &__address {
-    margin-bottom: var(--spacer-base);
-    @include for-desktop {
-      margin-right: var(--spacer-sm);
-      display: flex;
-      width: 100%;
-      flex-direction: column;
-    }
-  }
-
-  &__addresses {
-    margin-bottom: var(--spacer-xl);
-    @include for-desktop {
-      display: flex;
-    }
-  }
-
-  &__setAsDefault {
-    margin-bottom: var(--spacer-xl);
-  }
-}
-
-.sf-divider,
-.form__action-button--margin-bottom {
-  margin-bottom: var(--spacer-xl);
-}
+@import "./styles/userAddresses";
 </style>

--- a/packages/theme/modules/checkout/components/UserShippingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserShippingAddresses.vue
@@ -2,13 +2,13 @@
   <div>
     <SfAddressPicker
       :selected="`${currentAddressId}`"
-      class="shipping__addresses"
+      class="addresses"
       @change="setCurrentAddress($event)"
     >
       <SfAddress
         v-for="shippingAddress in addressesWithCountryName"
         :key="userShippingGetters.getId(shippingAddress)"
-        class="shipping__address"
+        class="address"
         :name="`${userShippingGetters.getId(shippingAddress)}`"
       >
         <UserAddressDetails :address="shippingAddress">
@@ -23,7 +23,7 @@
       :selected="value"
       name="setAsDefault"
       label="Use this address as my default one."
-      class="shipping__setAsDefault"
+      class="setAsDefault"
       @change="$emit('input', $event)"
     />
     <hr class="sf-divider">
@@ -95,33 +95,5 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-.shipping {
-  &__address {
-    margin-bottom: var(--spacer-base);
-    @include for-desktop {
-      margin-right: var(--spacer-sm);
-      display: flex;
-      width: calc(50% - var(--spacer-sm));
-      flex-direction: column;
-    }
-  }
-
-  &__addresses {
-    margin-bottom: var(--spacer-xl);
-    @include for-desktop {
-      display: flex;
-      flex-wrap: wrap;
-      margin-right: var(--spacer-sm)
-    }
-  }
-
-  &__setAsDefault {
-    margin-bottom: var(--spacer-xl);
-  }
-}
-
-.sf-divider,
-.form__action-button--margin-bottom {
-  margin-bottom: var(--spacer-xl);
-}
+@import "./styles/userAddresses";
 </style>

--- a/packages/theme/modules/checkout/components/styles/userAddresses.scss
+++ b/packages/theme/modules/checkout/components/styles/userAddresses.scss
@@ -1,0 +1,27 @@
+.address {
+  margin-bottom: var(--spacer-base);
+  @include for-desktop {
+    margin-right: var(--spacer-sm);
+    display: flex;
+    width: calc(50% - var(--spacer-sm));
+    flex-direction: column;
+  }
+}
+
+.addresses {
+  margin-bottom: var(--spacer-xl);
+  @include for-desktop {
+    display: flex;
+    flex-wrap: wrap;
+    margin-right: var(--spacer-sm)
+  }
+}
+
+.setAsDefault {
+  margin-bottom: var(--spacer-xl);
+}
+
+.sf-divider,
+.form__action-button--margin-bottom {
+  margin-bottom: var(--spacer-xl);
+}


### PR DESCRIPTION
Before this PR user addresses styles on checkout were fixed only on the shipping step. 

I realized that the SCSS code was duplicated for the shipping and billing step so I moved the SCSS code to a separate file. 

I changed class names (they are scoped so we don't need to use prefixes like .shipping__addresses or .billing__adresses.) to use simpler classes like .addresses and .address. 

Now styles for addresses in shipping and billing steps are correct and the code is not duplicated anymore.

#### Billing step
![Screenshot 2022-06-27 at 15 31 28](https://user-images.githubusercontent.com/11998249/175954648-a0375829-a329-4936-98e4-48128bb0d690.png)

#### Shipping step

![Screenshot 2022-06-27 at 15 36 45](https://user-images.githubusercontent.com/11998249/175954816-8e173f8d-399c-4a5b-9b5f-375dd7637794.png)

#### Mobile
![Screenshot 2022-06-27 at 15 37 20](https://user-images.githubusercontent.com/11998249/175954895-4060e01b-cf65-4b58-88b5-f27ff437df7a.png)


M2-709