### PR TITLE
refactor(checkout): simplify billing/checkout logic

### DIFF
--- a/packages/theme/helpers/checkout/address.ts
+++ b/packages/theme/helpers/checkout/address.ts
@@ -1,3 +1,4 @@
+import { isEqual } from 'lodash-es';
 import type { CustomerAddress, CartAddressInterface } from '~/modules/GraphQL/types';
 
 export const formatAddressReturnToData = (address: CartAddressInterface) => ({
@@ -53,3 +54,23 @@ export const getInitialCheckoutAddressForm = () : CheckoutAddressForm => ({
   postcode: '',
   telephone: '',
 });
+
+/**
+ * Try to find an address from the user's saved addresses that exactly matches the address that is bound to a cart.
+ *
+ * `useShipping().save()``sends an addressId to Magento to set the shipping address on the cart,
+ * but when you download the cart after that - the cart's endpoint response doesn't contain that addressId, just the address fields (street etc.)
+ * So the only choice left is to try to compare the fields of the addresses.
+ *
+ * This function exists because if a user returns to a cart whose shipping address was set before, we want the user address to be highlighted in the SfAddressPicker component.
+ *
+ * @param customerAddresses The addresses saved in a user's account
+ * @param cartAddress The address that is bound to the cart, @see Cart["billing_address"] Cart["shipping_addresses"]
+ *
+ */
+export const findUserAddressIdenticalToSavedCartAddress = (
+  customerAddresses: CustomerAddress[] | null,
+  cartAddress: CartAddressInterface,
+) : CustomerAddress => customerAddresses?.find(
+  (userAddress) => isEqual(addressFromApiToForm(userAddress), addressFromApiToForm(cartAddress)),
+) ?? null;

--- a/packages/theme/modules/checkout/components/UserBillingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserBillingAddresses.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <SfAddressPicker
-      :selected="`${selectedAddress}`"
+      :selected="`${currentAddressId}`"
       class="addresses"
-      @change="setCurrentAddress($event)"
+      @change="emitSetCurrentAddress($event)"
     >
       <SfAddress
         v-for="billingAddress in addressesWithCountryName"
@@ -46,8 +46,8 @@ export default defineComponent({
   },
   props: {
     currentAddressId: {
-      type: [String, Number],
-      required: true,
+      type: Number,
+      default: null,
     },
     value: {
       type: Boolean,
@@ -65,21 +65,12 @@ export default defineComponent({
   },
   emits: ['setCurrentAddress'],
   setup(props, { emit }) {
-    const setCurrentAddress = (addressId: string) => {
-      const selectedAddress = props.billingAddresses.find((address) => address.id === Number(addressId));
-      if (!selectedAddress) {
-        return;
+    const emitSetCurrentAddress = (addressId: number) => {
+      const address = props.billingAddresses.find(({ id }) => id === Number(addressId));
+      if (address) {
+        emit('setCurrentAddress', address);
       }
-
-      emit('setCurrentAddress', selectedAddress);
     };
-
-    const selectedAddress = computed(() => (
-      props.currentAddressId
-        ? props.currentAddressId
-        : props.billingAddresses.find((address) => address.default_billing)?.id ?? ''
-    ));
-
     const addressesWithCountryName = computed(() => props.billingAddresses.map((address) => ({
       ...address,
       countryName: props.countries
@@ -89,8 +80,7 @@ export default defineComponent({
     })));
 
     return {
-      selectedAddress,
-      setCurrentAddress,
+      emitSetCurrentAddress,
       addressesWithCountryName,
       userBillingGetters,
     };

--- a/packages/theme/modules/checkout/components/UserShippingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserShippingAddresses.vue
@@ -3,7 +3,7 @@
     <SfAddressPicker
       :selected="`${currentAddressId}`"
       class="addresses"
-      @change="setCurrentAddress($event)"
+      @change="emitSetCurrentAddress($event)"
     >
       <SfAddress
         v-for="shippingAddress in addressesWithCountryName"
@@ -49,8 +49,8 @@ export default defineComponent({
   },
   props: {
     currentAddressId: {
-      type: [String, Number],
-      required: true,
+      type: Number,
+      default: null,
     },
     value: {
       type: Boolean,
@@ -68,15 +68,12 @@ export default defineComponent({
   },
   emits: ['setCurrentAddress'],
   setup(props, { emit }) {
-    const setCurrentAddress = (addressId: string | number) => {
-      const selectedAddress = props.shippingAddresses.find((address) => address.id === Number(addressId));
-      if (!selectedAddress) {
-        return;
+    const emitSetCurrentAddress = (addressId: number) => {
+      const address = props.shippingAddresses.find(({ id }) => id === Number(addressId));
+      if (address) {
+        emit('setCurrentAddress', address);
       }
-
-      emit('setCurrentAddress', selectedAddress);
     };
-
     const addressesWithCountryName = computed(() => props.shippingAddresses.map((address) => ({
       ...address,
       countryName: props.countries
@@ -86,7 +83,7 @@ export default defineComponent({
     })));
 
     return {
-      setCurrentAddress,
+      emitSetCurrentAddress,
       addressesWithCountryName,
       userShippingGetters,
     };

--- a/packages/theme/modules/checkout/pages/Checkout/Billing.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Billing.vue
@@ -26,7 +26,11 @@
                 ...billingDetails,
                 region: { region_code: billingDetails.region },
               }"
-            />
+            >
+              <template #country>
+                {{ shippingDetailsCountryName }}
+              </template>
+            </UserAddressDetails>
           </div>
         </div>
       </div>
@@ -360,6 +364,11 @@ export default defineComponent({
 
     const countries = ref<Country[]>([]);
     const country = ref<Country | null>(null);
+
+    const shippingDetailsCountryName = computed(() => countries
+      .value
+      .find((countryItem) => countryItem.id === shippingDetails.value?.country.code)?.full_name_locale ?? '');
+
     const { isAuthenticated } = useUser();
     let oldBilling : CheckoutAddressForm | null = null;
     const sameAsShipping = ref(false);
@@ -481,13 +490,10 @@ export default defineComponent({
       const [defaultAddress = null] = userBillingGetters.getAddresses(loadedUserBilling, { default_shipping: true });
       const wasBillingAddressAlreadySetOnCart = Boolean(loadedBillingInfoBoundToCart);
 
-<<<<<<< HEAD
-=======
       // keep in mind default billing address is set on a customer's cart during cart creation
->>>>>>> 8578149e (chore: fix commit wording)
       if (wasBillingAddressAlreadySetOnCart) {
         const userAddressIdenticalToSavedCartAddress = findUserAddressIdenticalToSavedCartAddress(
-          loadedUserBilling.addresses,
+          loadedUserBilling?.addresses,
           loadedBillingInfoBoundToCart,
         );
 
@@ -523,6 +529,7 @@ export default defineComponent({
       setAsDefault,
       billingDetails,
       sameAsShipping,
+      shippingDetailsCountryName,
       addresses,
     };
   },

--- a/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
@@ -428,7 +428,7 @@ export default defineComponent({
 
       if (wasShippingAddressAlreadySetOnCart) {
         const userAddressIdenticalToSavedCartAddress = findUserAddressIdenticalToSavedCartAddress(
-          loadedUserShipping.addresses,
+          loadedUserShipping?.addresses,
           loadedShippingInfoBoundToCart,
         );
         handleSetCurrentAddress({ ...loadedShippingInfoBoundToCart, id: userAddressIdenticalToSavedCartAddress?.id });

--- a/packages/theme/modules/customer/getters/userBillingGetters.ts
+++ b/packages/theme/modules/customer/getters/userBillingGetters.ts
@@ -4,6 +4,8 @@ import { TransformedCustomerAddress } from '../composables/types';
 
 const userBillingGetters: UserBillingGetters<Customer, CustomerAddress, TransformedCustomerAddress> = {
   getAddresses: (billing, criteria?: Record<string, any>) => {
+    if (!billing || !billing.addresses) return [] as CustomerAddress[];
+
     if (!criteria || Object.keys(criteria).length === 0) {
       return billing.addresses;
     }


### PR DESCRIPTION
I refactored the Checkout and Billing pages a bit because it's the 2nd time something is returing from a retest and I was tired of the outdated logic in those components.

1. addressId are now always numbers (that's how they come from the api). String casts are used only when a function somewhere deeper down the line needs it
2. simplify logic of detecting whether the default address should be preselected. Preselection should only happen if a shipping/billing address weren't previously set on the cart. The logic from before PR doesn't quite work since the form approach changed since then
3. Make  UserBillingAddresses use two way binding for selecting the address, rather than an internal computed. This re-introduces the behavior seen in M2-333 but that's intended
4. Show country name instead of country code in "billing address is the same as shipping" address card

M2-869
