### PR TITLE
fix: m2-861 - merging cart doesn't work for bundled products

### DIFF
--- a/packages/theme/modules/customer/composables/useUser/index.ts
+++ b/packages/theme/modules/customer/composables/useUser/index.ts
@@ -189,23 +189,29 @@ export function useUser(): UseUserInterface {
       const cart = await app.context.$vsf.$magento.api.customerCart();
       const newCartId = cart.data.customerCart.id;
 
-      if (newCartId && currentCartId && currentCartId !== newCartId) {
-        const { data: dataMergeCart } = await app.context.$vsf.$magento.api.mergeCarts(
-          {
-            sourceCartId: currentCartId,
-            destinationCartId: newCartId,
-          },
-        );
+      try {
+        if (newCartId && currentCartId && currentCartId !== newCartId) {
+          const { data: dataMergeCart } = await app.context.$vsf.$magento.api.mergeCarts(
+            {
+              sourceCartId: currentCartId,
+              destinationCartId: newCartId,
+            },
+          );
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        setCart(dataMergeCart.mergeCarts);
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          setCart(dataMergeCart.mergeCarts);
 
-        apiState.setCartId(dataMergeCart.mergeCarts.id);
-      } else {
+          apiState.setCartId(dataMergeCart.mergeCarts.id);
+        } else {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          setCart(cart.data.customerCart);
+        }
+      } catch {
+        // Workaround for Magento 2.4.4 mergeCarts mutation error related with Bundle products
+        // It can be removed when Magento 2.4.5 will be release
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         setCart(cart.data.customerCart);
       }
-
       error.value.login = null;
     } catch (err) {
       error.value.login = err;


### PR DESCRIPTION
Before this PR,  the App crashed during merging carts with bundled products.

This is caused by an internal error in Magento 2.4.3 and 2.4.4.

On the Magento 2.4-dev branch, it works as well so probably it will work in Magento 2.4.5

For now, I just handled errors thrown by mergeCarts mutation.

After this PR it's possible to log in when you have bundled product in the cart. The app doesn't crash anymore.