### PR TITLE
fix: checkouts discounted price is wrongly displayed

### DIFF
--- a/packages/theme/modules/checkout/getters/cartGetters.ts
+++ b/packages/theme/modules/checkout/getters/cartGetters.ts
@@ -5,12 +5,12 @@ import type { Price } from '~/modules/catalog/types';
 import type { ProductAttribute, Product } from '~/modules/catalog/product/types';
 import { PaymentMethodInterface } from '~/modules/checkout/types';
 import {
-  CartItemInterface,
   Cart,
   Discount,
   ProductInterface,
   SelectedShippingMethod,
   ConfigurableCartItem,
+  CartItemInterface,
 } from '~/modules/GraphQL/types';
 import { CartGetters as CartGettersBase, CartDiscount, Coupon } from '~/getters/types';
 import { getName, getSlug as getSlugGetter, getProductThumbnailImage } from '~/modules/catalog/product/getters/productGetters';

--- a/packages/theme/modules/checkout/pages/Checkout/Payment.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Payment.vue
@@ -68,10 +68,7 @@
         <SfTableData class="table__data price">
           <SfPrice
             :regular="$fc(cartGetters.getItemPrice(product).regular)"
-            :special="
-              cartGetters.getItemPrice(product).special &&
-                $fc(cartGetters.getItemPrice(product).special)
-            "
+            :special=" cartGetters.getItemPrice(product).special && $fc(getRowTotal(product)) "
             class="product-price"
           />
         </SfTableData>
@@ -178,6 +175,7 @@ import {
   useContext,
   onMounted,
 } from '@nuxtjs/composition-api';
+
 import cartGetters from '~/modules/checkout/getters/cartGetters';
 import { useImage } from '~/composables';
 import useMakeOrder from '~/modules/checkout/composables/useMakeOrder';
@@ -185,7 +183,7 @@ import useCart from '~/modules/checkout/composables/useCart';
 import getShippingMethodPrice from '~/helpers/checkout/getShippingMethodPrice';
 import { removeItem } from '~/helpers/asyncLocalStorage';
 import { isPreviousStepValid } from '~/helpers/checkout/steps';
-import type { BundleCartItem, ConfigurableCartItem } from '~/modules/GraphQL/types';
+import type { BundleCartItem, ConfigurableCartItem, CartItemInterface } from '~/modules/GraphQL/types';
 
 export default defineComponent({
   name: 'ReviewOrderAndPayment',
@@ -243,7 +241,7 @@ export default defineComponent({
     );
 
     const { getMagentoImage, imageSizes } = useImage();
-
+    const getRowTotal = (product: CartItemInterface) => cartGetters.getItemPrice(product).regular - cartGetters.getItemPrice(product).special;
     return {
       cart,
       cartGetters,
@@ -263,6 +261,7 @@ export default defineComponent({
       getBundles,
       getMagentoImage,
       imageSizes,
+      getRowTotal,
     };
   },
 });


### PR DESCRIPTION
## Description
checkout discounted price is wrongly displayed

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Given: prices sum of all products in user cart has to be > 200$.

1. Go to checkout.
2. Proceed to Payment section.

## Screenshots (if appropriate):
![Screenshot 2022-06-29 at 10 39 23](https://user-images.githubusercontent.com/16045377/176392621-141e766b-e8f7-4fed-96b0-4680bb41d8b6.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
