### PR TITLE
fix: m2-618. fixed mega menu z-index in safari

### DIFF
--- a/packages/theme/components/Header/Navigation/HeaderNavigationSubcategories.vue
+++ b/packages/theme/components/Header/Navigation/HeaderNavigationSubcategories.vue
@@ -181,7 +181,7 @@ export default defineComponent({
 .header-navigation {
   &__subcategories {
     position: absolute;
-    z-index: 10;
+    z-index: 1;
     background-color: #fff;
     box-shadow: 0 3px var(--c-primary);
     left: 0;


### PR DESCRIPTION
Before this PR mega menu was covered by my account content in safari

After this PR, content doesn't cover the mega menu
<img width="1365" alt="Screen Shot 2022-06-29 at 12 48 18" src="https://user-images.githubusercontent.com/11998249/176419580-051d5ef2-6c56-40ba-9711-d37250ea1526.png">
