### PR TITLE
fix: empty list of currencies while trying to change currency

### DIFF
--- a/packages/theme/components/AppHeader.vue
+++ b/packages/theme/components/AppHeader.vue
@@ -12,8 +12,14 @@
       </template>
       <template #aside>
         <div class="sf-header__switchers">
-          <CurrencySelector class="smartphone-only" />
-          <StoreSwitcher class="smartphone-only" />
+          <CurrencySelector
+            v-if="hasCurrencyToSelect"
+            class="smartphone-only"
+          />
+          <StoreSwitcher
+            v-if="hasStoresToSelect"
+            class="smartphone-only"
+          />
         </div>
       </template>
       <template #header-icons="{ activeIcon }">
@@ -127,22 +133,21 @@ import { useWishlist } from '~/modules/wishlist/composables/useWishlist';
 import { useUser } from '~/modules/customer/composables/useUser';
 import { useWishlistStore } from '~/modules/wishlist/store/wishlistStore';
 import type { CategoryTree, ProductInterface } from '~/modules/GraphQL/types';
-import CurrencySelector from '~/components/CurrencySelector.vue';
 import HeaderLogo from '~/components/HeaderLogo.vue';
 import SvgImage from '~/components/General/SvgImage.vue';
-import StoreSwitcher from '~/components/StoreSwitcher.vue';
+import { useTopBar } from './TopBar/useTopBar';
 
 export default defineComponent({
   components: {
     HeaderNavigation,
     SfHeader,
     SfOverlay,
-    CurrencySelector,
     HeaderLogo,
-    StoreSwitcher,
     SvgImage,
     SfButton,
     SfBadge,
+    CurrencySelector: () => import('~/components/CurrencySelector.vue'),
+    StoreSwitcher: () => import('~/components/StoreSwitcher.vue'),
     SearchBar: () => import('~/components/Header/SearchBar/SearchBar.vue'),
     SearchResults: () => import(
       /* webpackPrefetch: true */ '~/components/Header/SearchBar/SearchResults.vue'
@@ -157,6 +162,8 @@ export default defineComponent({
     const { loadTotalQty: loadCartTotalQty, cart } = useCart();
     const { loadItemsCount: loadWishlistItemsCount } = useWishlist();
     const { categories: categoryList, load: categoriesListLoad } = useCategory();
+
+    const { hasCurrencyToSelect, hasStoresToSelect } = useTopBar();
 
     const isSearchOpen = ref(false);
     const productSearchResults = ref<ProductInterface[] | null>(null);
@@ -205,6 +212,8 @@ export default defineComponent({
       toggleWishlistSidebar,
       wishlistHasProducts,
       wishlistItemsQty,
+      hasCurrencyToSelect,
+      hasStoresToSelect,
     };
   },
 });


### PR DESCRIPTION
## Description
- currency and store switcher will no behave in the same way on the desktop and the mobile

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
bugfix

## How Has This Been Tested?
1. go to https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io/default
2. create account
3. add shipping address in user settings and set it as default
4. add product to cart and proceed to chekout
5. try to select shipping method

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
