### PR TITLE
fix: m2-839. product names with special signs are wrongly encoded

### DIFF
--- a/packages/theme/modules/customer/pages/MyAccount/OrderHistory/SingleOrder/SingleOrder.vue
+++ b/packages/theme/modules/customer/pages/MyAccount/OrderHistory/SingleOrder/SingleOrder.vue
@@ -28,12 +28,15 @@
             :key="item.product_sku"
           >
             <SfTableData class="products__name">
-              {{ item.product_name }}
+              <span v-html="$dompurify(item.product_name)" />
               <div
                 v-for="option in item.selected_options"
                 :key="option.label"
               >
-                <span class="configurable-option-label">{{ option.label }}</span>
+                <span
+                  class="configurable-option-label"
+                  v-html="$dompurify(option.label)"
+                />
                 <span>{{ option.value }}</span>
               </div>
             </SfTableData>


### PR DESCRIPTION
## Description
- add proper encoding in the customer order history

## Related Issue
-

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Buy any product with special signs, i. e. "Pursuit Lumaflex™ Tone Band".
2. Go to "My account" -> "Order history".
3. Open details of last order.

## Screenshots (if appropriate):
![Screenshot 2022-07-01 at 08 47 20](https://user-images.githubusercontent.com/16045377/176839933-c28f161e-2545-4205-bbd0-31af1f6358b1.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
