### PR TITLE
fix!: m2-668 fixed price recalculation for configurable products

### DIFF
--- a/packages/api-client/src/api/productDetail/productDetailsQuery.ts
+++ b/packages/api-client/src/api/productDetail/productDetailsQuery.ts
@@ -11,7 +11,6 @@ export default gql`
     $pageSize: Int = 10,
     $currentPage: Int = 1,
     $sort: ProductAttributeSortInput
-    $configurations: [ID!]
   ) {
     products(search: $search, filter: $filter, sort: $sort, pageSize: $pageSize, currentPage: $currentPage) {
       items {
@@ -91,28 +90,6 @@ export default gql`
         options_container
         special_to_date
         ... on ConfigurableProduct {
-            price_range {
-            maximum_price {
-              final_price {
-                currency
-                value
-              }
-              regular_price {
-                currency
-                value
-              }
-            }
-            minimum_price {
-              final_price {
-                currency
-                value
-              }
-              regular_price {
-                currency
-                value
-              }
-            }
-          }
           configurable_options {
             attribute_code
             attribute_uid
@@ -126,45 +103,6 @@ export default gql`
                 value
               }
               uid
-            }
-          }
-          configurable_product_options_selection(configurableOptionValueUids: $configurations) {
-            options_available_for_selection {
-              attribute_code
-              option_value_uids
-            }
-            media_gallery {
-              disabled
-              label
-              position
-              url
-            }
-            variant {
-              uid
-              sku
-              name
-              price_range {
-                maximum_price {
-                  final_price {
-                    currency
-                    value
-                  }
-                  regular_price {
-                    currency
-                    value
-                  }
-                }
-                minimum_price {
-                  final_price {
-                    currency
-                    value
-                  }
-                  regular_price {
-                    currency
-                    value
-                  }
-                }
-              }
             }
           }
         }

--- a/packages/theme/modules/catalog/pages/product.vue
+++ b/packages/theme/modules/catalog/pages/product.vue
@@ -132,7 +132,7 @@ export default defineComponent({
     });
 
     onMounted(async () => {
-      const { data } = await query<ProductDetailsQuery>(getProductPriceBySkuGql, { sku: id });
+      const { data } = await query<ProductDetailsQuery>(getProductPriceBySkuGql, getBaseSearchQuery());
 
       product.value = merge({}, product.value, data.products?.items?.[0] as Product);
     });

--- a/packages/theme/modules/catalog/product/queries/getProductPriceBySku.gql.ts
+++ b/packages/theme/modules/catalog/product/queries/getProductPriceBySku.gql.ts
@@ -24,11 +24,60 @@ const fragmentPriceRangeFields = `
 `;
 
 export default `
-  query getProductPriceBySku($sku: String) {
-    products(filter: {sku: {eq: $sku}}) {
+  query getProductPriceBySku(
+    $filter: ProductAttributeFilterInput,
+    $configurations: [ID!]
+  ) {
+    products(filter: $filter) {
       items {
         price_range {
           ...PriceRangeFields
+        }
+
+        ... on ConfigurableProduct {
+          price_range {
+            maximum_price {
+              final_price {
+                currency
+                value
+              }
+              regular_price {
+                currency
+                value
+              }
+            }
+            minimum_price {
+              final_price {
+                currency
+                value
+              }
+              regular_price {
+                currency
+                value
+              }
+            }
+          }
+
+          configurable_product_options_selection(configurableOptionValueUids: $configurations) {
+            options_available_for_selection {
+              attribute_code
+              option_value_uids
+            }
+            media_gallery {
+              disabled
+              label
+              position
+              url
+            }
+            variant {
+              uid
+              sku
+              name
+              price_range {
+                ...PriceRangeFields
+              }
+            }
+          }
         }
 
         ... on BundleProduct {
@@ -50,26 +99,7 @@ export default `
                 sku
                 name
                 price_range {
-                  maximum_price {
-                    final_price {
-                      currency
-                      value
-                    }
-                    regular_price {
-                      currency
-                      value
-                    }
-                  }
-                  minimum_price {
-                    final_price {
-                      currency
-                      value
-                    }
-                    regular_price {
-                      currency
-                      value
-                    }
-                  }
+                   ...PriceRangeFields
                 }
               }
             }


### PR DESCRIPTION
The second part of https://github.com/vuestorefront/magento2/pull/1146

### Before
Before this PR, prices were not recalculated properly for configurable products.
Reason: prices for product variants were cached in Redis. 

### After
After this PR prices are recalculated properly for configurable products. 


### Solution
I moved loading data of variants from a query that is run on server-side (`packages/api-client/src/api/productDetail/productDetailsQuery.ts`) to the query that is run on client-side (`packages/theme/modules/catalog/product/queries/getProductPriceBySku.gql.ts`)

M2-668