### PR TITLE
fix: m2-596. my account province state value displayed as a code

### DIFF
--- a/packages/theme/modules/checkout/pages/Checkout/Billing.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Billing.vue
@@ -486,7 +486,6 @@ export default defineComponent({
         loadUserBilling(),
         loadCountries(),
       ]);
-
       const [defaultAddress = null] = userBillingGetters.getAddresses(loadedUserBilling, { default_shipping: true });
       const wasBillingAddressAlreadySetOnCart = Boolean(loadedBillingInfoBoundToCart);
 
@@ -501,7 +500,9 @@ export default defineComponent({
       } else if (defaultAddress) {
         handleSetCurrentAddress(defaultAddress);
       }
-
+      if (billingDetails.value?.country_code) {
+        country.value = await searchCountry({ id: billingDetails.value.country_code });
+      }
       userBilling.value = loadedUserBilling;
       countries.value = loadedCountries;
     });

--- a/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
@@ -435,6 +435,9 @@ export default defineComponent({
       } else if (defaultAddress) {
         handleSetCurrentAddress(defaultAddress);
       }
+      if (shippingDetails.value?.country_code) {
+        country.value = await searchCountry({ id: shippingDetails.value.country_code });
+      }
       userShipping.value = loadedUserShipping;
       countries.value = loadedCountries;
     });


### PR DESCRIPTION
## Description
- if a country has a region list the name of the region will be displayed instead of a code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Go to the checkout as a guest
2. Go to the shipping step, add shipping details, and select shipping method. Be sure that you have selected a country with available regions (eg. the US)
3. Go to the billing step
4. Go back to the shipping step
5. Observe that the region is displayed as a name, not the code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
