### PR TITLE
fix: login registration does not work with recaptcha

### DIFF
--- a/packages/theme/modules/customer/composables/useUser/index.ts
+++ b/packages/theme/modules/customer/composables/useUser/index.ts
@@ -30,7 +30,8 @@ import type {
  */
 export function useUser(): UseUserInterface {
   const customerStore = useCustomerStore();
-  const { app } = useContext();
+  // @ts-ignore
+  const { app, $recaptcha } = useContext();
   const { setCart } = useCart();
   const { send: sendNotification } = useUiNotification();
   const loading: Ref<boolean> = ref(false);
@@ -269,16 +270,13 @@ export function useUser(): UseUserInterface {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         throw new Error(joinedErrors);
       }
-
-      // if (recaptchaToken) { // todo: move recaptcha to separate module
-      //   // generate a new token for the login action
-      //   const { recaptchaInstance } = params;
-      //   const newRecaptchaToken = await recaptchaInstance.getResponse();
-      //
-      //   return factoryParams.logIn(context, { username: email, password, recaptchaToken: newRecaptchaToken });
-      // }
       error.value.register = null;
-      await login({ user: { email, password }, customQuery: {} });
+      let loginRecaptchaToken = '';
+      if ($recaptcha && recaptchaToken) {
+        loginRecaptchaToken = await $recaptcha.getResponse();
+      }
+
+      await login({ user: { email, password, recaptchaToken: loginRecaptchaToken }, customQuery: {} });
     } catch (err) {
       error.value.register = err;
       Logger.error('useUser/register', err);

--- a/packages/theme/plugins/token-expired.ts
+++ b/packages/theme/plugins/token-expired.ts
@@ -4,7 +4,7 @@ import type { UiNotification } from '~/composables/useUiNotification';
 import { useCustomerStore } from '~/modules/customer/stores/customer';
 
 export const hasGraphqlAuthorizationError = (res: ApolloQueryResult<unknown>) => res?.errors
-  ?.some((error) => error.extensions.category === 'graphql-authorization') ?? false;
+  ?.some((error) => error?.extensions?.category === 'graphql-authorization') ?? false;
 
 const plugin : Plugin = ({ $pinia, app }) => {
   const customerStore = useCustomerStore($pinia);


### PR DESCRIPTION
## Description
Previously, if reCaptcha was enabled, the registration process was breaking at the login step due to the reuse of the same reCaptcha token. Now we create a new reCaptcha token for the login step.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
WITH RECAPTCHA ENABLED
1. Open Magento 2 integration page.
2. Click account icon in top menu.
3. Choose option to register a new account.
4. Add data to all fields.
5. Click CTA button in registration form.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
