### PR TITLE
docs: updated installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,7 @@ This project is a Magento 2 integration for Vue Storefront 2.
 
 ## How to start if you want to try out the integration
 
-```
-yarn global add @vue-storefront/cli
-```
-```
-vsf init <project_name> && cd <project_name> && yarn && yarn dev
-```
+Please follow the [installation guide](https://docs.vuestorefront.io/magento/installation-setup/installation.html)
 
 ## How to start if you want to contribute?
 

--- a/docs/installation-setup/installation.md
+++ b/docs/installation-setup/installation.md
@@ -17,7 +17,7 @@ node -v
 The easiest way to get started with Vue Storefront is to set up your project using our CLI. You can run it using the following command:
 
 ```bash
-npx @vue-storefront/cli init
+npx @vue-storefront/cli generate store
 ```
 
 It will ask you to enter the project's name and select the e-commerce platform you wish to use. Once selected, the CLI will create project files in the directory matching your project name.

--- a/packages/api-client/README.md
+++ b/packages/api-client/README.md
@@ -22,12 +22,7 @@ This integration developed by superheroes from [Caravel](https://github.com/cara
 
 ## How to start if you want to try out the integration
 
-```
-yarn global add @vue-storefront/cli
-```
-```
-vsf init <project_name> && cd <project_name> && yarn && yarn dev
-```
+Please follow the [installation guide](https://docs.vuestorefront.io/magento/installation-setup/installation.html)
 
 ## How to start if you want to contribute?
 

--- a/packages/composables/README.md
+++ b/packages/composables/README.md
@@ -22,12 +22,7 @@ This integration developed by superheroes from [Caravel](https://github.com/cara
 
 ## How to start if you want to try out the integration
 
-```
-yarn global add @vue-storefront/cli
-```
-```
-vsf init <project_name> && cd <project_name> && yarn && yarn dev
-```
+Please follow the [installation guide](https://docs.vuestorefront.io/magento/installation-setup/installation.html)
 
 ## How to start if you want to contribute?
 


### PR DESCRIPTION
### Before
Installation command that was described `vsf init` has been depracated so our docks was not up tom date

### After
We updated the readme files and installation guide to use `npx @vue-storefront/cli generate store` so the documentation is up to date.