### PR TITLE
feat: update behaviour of the addresses on the checkout

### DIFF
--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -183,6 +183,7 @@ export default {
   "Thank you": "Danke",
   "Thank You Inbox": "Wenn die Nachricht nicht in Ihrem Posteingang ankommt, versuchen Sie es mit einer anderen E-Mail-Adresse, mit der Sie sich möglicherweise registriert haben.",
   "Total": "Gesamt",
+  "Order Total": "Auftragssumme",
   "Total items": "Gesamtanzahl",
   "Total price": "Gesamtpreis",
   "Update password": "Passwort aktualisieren",
@@ -280,5 +281,7 @@ export default {
   "Passwords don't match":"Passwörter stimmen nicht überein",
   "The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)":"Das Passwort muss mindestens 8 Zeichen lang sein und muss mindestens enthalten: 1 Groß- oder Kleinbuchstabe, 1 Ziffer oder ein Sonderzeichen (z. B. , . _ & ? usw.)",
   "Show all products":"Alle Produkte anzeigen",
+  "Select previously saved address":"Zuvor gespeicherte Adresse auswählen",
+  "Enter different address":"Geben Sie eine andere Adresse ein",
   "You must confirm your account. Please check your email for the confirmation link.": "Sie müssen Ihr Konto bestätigen. Bitte überprüfen Sie Ihre E-Mail auf den Bestätigungslink.",
 };

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -178,6 +178,7 @@ export default {
   "Thank you": "Thank you",
   "Thank You Inbox": "If the message is not arriving in your inbox, try another email address you might’ve used to register.",
   "Total": "Total",
+  "Order Total": "Order Total",
   "Total items": "Total items",
   "Total price": "Total price",
   "Update password": "Update password",
@@ -278,5 +279,7 @@ export default {
   "Passwords don't match":"Passwords don't match",
   "The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)":"The password must be at least 8 characters long and must contain at least: 1 uppercase or lowercase letter, 1 number, or one special character (E.g. , . _ & ? etc)",
   "Show all products":"Show all products",
+  "Select previously saved address":"Select previously saved address",
+  "Enter different address":"Enter different address",
   "You must confirm your account. Please check your email for the confirmation link.": "You must confirm your account. Please check your email for the confirmation link.",
 };

--- a/packages/theme/modules/checkout/components/UserBillingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserBillingAddresses.vue
@@ -18,19 +18,12 @@
         </UserAddressDetails>
       </SfAddress>
     </SfAddressPicker>
-    <SfCheckbox
-      :selected="value"
-      name="setAsDefault"
-      label="Use this address as my default one."
-      class="setAsDefault"
-      @change="$emit('input', $event)"
-    />
     <hr class="sf-divider">
   </div>
 </template>
 
 <script lang="ts">
-import { SfCheckbox, SfAddressPicker } from '@storefront-ui/vue';
+import { SfAddressPicker } from '@storefront-ui/vue';
 import { computed, defineComponent } from '@nuxtjs/composition-api';
 import type { PropType } from '@nuxtjs/composition-api';
 import userBillingGetters from '~/modules/customer/getters/userBillingGetters';
@@ -40,7 +33,6 @@ import type { Country, CustomerAddress } from '~/modules/GraphQL/types';
 export default defineComponent({
   name: 'UserBillingAddresses',
   components: {
-    SfCheckbox,
     SfAddressPicker,
     UserAddressDetails,
   },

--- a/packages/theme/modules/checkout/components/UserShippingAddresses.vue
+++ b/packages/theme/modules/checkout/components/UserShippingAddresses.vue
@@ -18,20 +18,12 @@
         </UserAddressDetails>
       </SfAddress>
     </SfAddressPicker>
-    <SfCheckbox
-      v-show="currentAddressId"
-      :selected="value"
-      name="setAsDefault"
-      label="Use this address as my default one."
-      class="setAsDefault"
-      @change="$emit('input', $event)"
-    />
     <hr class="sf-divider">
   </div>
 </template>
 
 <script lang="ts">
-import { SfCheckbox, SfAddressPicker } from '@storefront-ui/vue';
+import { SfAddressPicker } from '@storefront-ui/vue';
 import { computed, defineComponent } from '@nuxtjs/composition-api';
 import type { PropType } from '@nuxtjs/composition-api';
 
@@ -43,7 +35,6 @@ import { Countries } from '~/composables';
 export default defineComponent({
   name: 'UserShippingAddresses',
   components: {
-    SfCheckbox,
     SfAddressPicker,
     UserAddressDetails,
   },

--- a/packages/theme/modules/checkout/composables/useShipping/index.ts
+++ b/packages/theme/modules/checkout/composables/useShipping/index.ts
@@ -28,7 +28,7 @@ export function useShipping(): UseShippingInterface {
 
     try {
       loading.value = true;
-      if (!cart?.value?.shipping_addresses) {
+      if (cart?.value?.shipping_addresses.length === 0) {
         await loadCart(params);
       }
 

--- a/packages/theme/modules/checkout/pages/Checkout/Billing.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Billing.vue
@@ -6,6 +6,12 @@
       :title="$t('Billing address')"
       class="sf-heading--left sf-heading--no-underline title"
     />
+    <SfHeading
+      v-e2e="'shipping-heading'"
+      :level="4"
+      :title="$t('Select previously saved address')"
+      class="sf-heading--left sf-heading--no-underline form-subtitle"
+    />
     <form @submit.prevent="handleSubmit(handleAddressSubmit(reset))">
       <SfCheckbox
         v-e2e="'copy-address'"
@@ -47,6 +53,12 @@
         v-if="!sameAsShipping && isAddNewAddressFormVisible"
         class="form"
       >
+        <SfHeading
+          v-e2e="'shipping-heading'"
+          :level="4"
+          :title="$t('Enter different address')"
+          class="sf-heading--left sf-heading--no-underline form-subtitle"
+        />
         <ValidationProvider
           v-slot="{ errors }"
           name="firstname"
@@ -403,6 +415,7 @@ export default defineComponent({
           ...billingDetails.value,
           customerAddressId: addressId === null ? null : String(addressId),
           sameAsShipping: sameAsShipping.value,
+          save_in_address_book: false,
         },
       };
       await save(billingDetailsData);
@@ -486,7 +499,7 @@ export default defineComponent({
         loadUserBilling(),
         loadCountries(),
       ]);
-      const [defaultAddress = null] = userBillingGetters.getAddresses(loadedUserBilling, { default_shipping: true });
+      const [defaultAddress = null] = userBillingGetters.getAddresses(loadedUserBilling, { default_billing: true });
       const wasBillingAddressAlreadySetOnCart = Boolean(loadedBillingInfoBoundToCart);
 
       // keep in mind default billing address is set on a customer's cart during cart creation
@@ -645,6 +658,18 @@ export default defineComponent({
     &:hover {
       color: white;
     }
+  }
+}
+
+.title, .form-subtitle {
+  margin: var(--spacer-xl) 0 var(--spacer-base) 0;
+
+}
+
+.form-subtitle {
+  width: 100%;
+  .sf-heading__title {
+    font-weight: bold;
   }
 }
 </style>

--- a/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
@@ -6,7 +6,12 @@
       :title="$t('Shipping address')"
       class="sf-heading--left sf-heading--no-underline title"
     />
-
+    <SfHeading
+      v-e2e="'shipping-heading'"
+      :level="4"
+      :title="$t('Select previously saved address')"
+      class="sf-heading--left sf-heading--no-underline form-subtitle"
+    />
     <form @submit.prevent="handleSubmit(handleAddressSubmit(reset))">
       <UserShippingAddresses
         v-if="isAuthenticated && hasSavedShippingAddress"
@@ -21,6 +26,12 @@
         v-if="isAddNewAddressFormVisible"
         class="form"
       >
+        <SfHeading
+          v-e2e="'shipping-heading'"
+          :level="4"
+          :title="$t('Enter different address')"
+          class="sf-heading--left sf-heading--no-underline form-subtitle"
+        />
         <ValidationProvider
           v-slot="{ errors }"
           name="firstname"
@@ -360,6 +371,7 @@ export default defineComponent({
       const shippingDetailsData = {
         ...shippingDetails.value,
         customerAddressId: addressId,
+        save_in_address_book: false,
       };
       await mergeItem('checkout', { shipping: shippingDetailsData });
 
@@ -422,7 +434,6 @@ export default defineComponent({
         loadUserShipping(),
         loadCountries(),
       ]);
-
       const [defaultAddress = null] = userShippingGetters.getAddresses(loadedUserShipping, { default_shipping: true });
       const wasShippingAddressAlreadySetOnCart = Boolean(loadedShippingInfoBoundToCart);
 
@@ -568,7 +579,15 @@ export default defineComponent({
   }
 }
 
-.title {
+.title, .form-subtitle {
   margin: var(--spacer-xl) 0 var(--spacer-base) 0;
+
+}
+
+.form-subtitle {
+  width: 100%;
+  .sf-heading__title {
+    font-weight: bold;
+  }
 }
 </style>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Shipping address - behavior on the checkout:

- link ‘Use this address as my default one’ should not be displayed
- headings of the sections are displayed for selecting address and entering new address (see attached preview for the reference)
- when a user adds a new address using the form, it shouldn’t be saved in the address book

Billing address - behavior on the checkout:
- if there is not default billing address in address book, no one address should be selected on billing step
- if there is a default billing address in the address book, it should be selected on the billing step
- link ‘Use this address as my default one’ should not be displayed
- when a user adds a new address using the form, it shouldn’t be saved in the address book

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
