### PR TITLE
fix: added limit for product gallery size

### DIFF
--- a/packages/theme/modules/catalog/product/getters/productGetters.ts
+++ b/packages/theme/modules/catalog/product/getters/productGetters.ts
@@ -89,7 +89,7 @@ export const getPrice = (product: ProductInterface): Price => {
   };
 };
 
-export const getGallery = (product: Product): MediaGalleryItem[] => {
+export const getGallery = (product: Product, maxGallerySize = 4): MediaGalleryItem[] => {
   const images = [];
 
   if (!product?.media_gallery && !product?.configurable_product_options_selection?.media_gallery) {
@@ -109,7 +109,7 @@ export const getGallery = (product: Product): MediaGalleryItem[] => {
     });
   }
 
-  return images;
+  return images.slice(0, maxGallerySize);
 };
 
 export const getCoverImage = (product: Product): string => {


### PR DESCRIPTION
### Before
When it was more than four images in the gallery, the layout of PDP was broken:
![Screenshot 2022-07-13 at 15 28 11](https://user-images.githubusercontent.com/11998249/178745018-5619d522-df88-488f-98be-d387719a3eb5.png)


### After
There can max four items in the product gallery

![Screenshot 2022-07-13 at 15 29 01](https://user-images.githubusercontent.com/11998249/178745225-d68a38eb-cd05-4e96-997a-64a92a89399e.png)


**Note**: I know it's not a perfect solution, but because of Storefront UI constraints, I don't have a better idea for now. 
We need to wait until it is fixed in SFUI.