### PR TITLE
fix: hide 'select prev added address labelsz for not logged-in customers

### DIFF
--- a/packages/theme/modules/checkout/pages/Checkout/Billing.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Billing.vue
@@ -7,6 +7,7 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <SfHeading
+      v-if="hasSavedBillingAddress"
       v-e2e="'shipping-heading'"
       :level="4"
       :title="$t('Select previously saved address')"
@@ -54,6 +55,7 @@
         class="form"
       >
         <SfHeading
+          v-if="hasSavedShippingAddress"
           v-e2e="'shipping-heading'"
           :level="4"
           :title="$t('Enter different address')"

--- a/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
+++ b/packages/theme/modules/checkout/pages/Checkout/Shipping.vue
@@ -7,6 +7,7 @@
       class="sf-heading--left sf-heading--no-underline title"
     />
     <SfHeading
+      v-if="hasSavedShippingAddress"
       v-e2e="'shipping-heading'"
       :level="4"
       :title="$t('Select previously saved address')"
@@ -27,6 +28,7 @@
         class="form"
       >
         <SfHeading
+          v-if="hasSavedShippingAddress"
           v-e2e="'shipping-heading'"
           :level="4"
           :title="$t('Enter different address')"


### PR DESCRIPTION
### Before
"Select previously saved address" and "enter different address" labels in the Shipping and Billing steps of checkout were dis
played f
or all customer

### After

"Select previously saved address" and "enter different address" labels in the Shipping and Billing checkout steps are displayed only for logged-in customers with addresses. 