### PR TITLE
Fix bug when media_gallery array is empty

### DIFF
--- a/packages/theme/modules/catalog/product/getters/productGetters.ts
+++ b/packages/theme/modules/catalog/product/getters/productGetters.ts
@@ -92,11 +92,11 @@ export const getPrice = (product: ProductInterface): Price => {
 export const getGallery = (product: Product): MediaGalleryItem[] => {
   const images = [];
 
-  if (!product?.media_gallery && !product?.configurable_product_options_selection?.media_gallery) {
+  if (!product?.media_gallery.length && !product?.configurable_product_options_selection?.media_gallery.length) {
     return images;
   }
 
-  const selectedGallery = product.configurable_product_options_selection?.media_gallery
+  const selectedGallery = product.configurable_product_options_selection?.media_gallery.length
     ? product.configurable_product_options_selection.media_gallery
     : product.media_gallery;
 


### PR DESCRIPTION
In `getGallery` rather check the length of an array to get an accurate bool value than simple the array which will always return true.

## Related Issue
#1266

## Motivation and Context
If product type is `configurable_product` then check the length of the `media_gallery` array to get an accurate bool value, as an array will always return true.


