### PR TITLE
fix: images in product gallery are overlayed with main image

### DIFF
--- a/packages/theme/modules/catalog/product/components/product-types/styles.scss
+++ b/packages/theme/modules/catalog/product/components/product-types/styles.scss
@@ -161,6 +161,12 @@
   }
 }
 
+::v-deep .sf-gallery__thumbs {
+  .sf-image-loaded {
+    display: block;
+  }
+}
+
 @keyframes moveicon {
   0% {
     transform: translate3d(0, 0, 0) rotate(90deg) scale(1, -1);


### PR DESCRIPTION
### Before 
Product gallery thumbs had wrong with on PDP in Safari browser.
![Screenshot 2022-07-18 at 14 03 45](https://user-images.githubusercontent.com/11998249/179507214-a98606c9-4a87-4377-be72-73f2231373e0.png)


### After 
Product gallery thumbs have the correct width in the Safari browser.

![Screenshot 2022-07-18 at 14 04 31](https://user-images.githubusercontent.com/11998249/179507354-d8f6cf00-bb38-46f4-b1c5-d18889853c5a.png)

