### PR TITLE
fix: don't inclue query params in urlPathToFind

### DIFF
--- a/packages/theme/modules/catalog/category/helpers/useTraverseCategory.ts
+++ b/packages/theme/modules/catalog/category/helpers/useTraverseCategory.ts
@@ -18,7 +18,7 @@ export function useTraverseCategory() {
   const loadCategoryTree = () => categoryStore.load();
   const activeCategory = computed(() => {
     // on localhost the default store is localhost:3000/default/ but in a multi-store Magento instance this can change
-    const urlPathToFind = route.value.fullPath
+    const urlPathToFind = route.value.path
       .replace(context.app.localePath('/c'), '')
       .replace(/^\//, '')
       .replace('.html', '');


### PR DESCRIPTION
this commit was made because if you went to a category and changed to
the 2nd page, the currently active category's name would not appear
after hard refreshing the page

this was happening because activeCategory used route.value.fullPath,
which includes the query params. So after the regex pipeline from
urlPathToFind, the value passed to findActiveCategory() was
"men?page=2" (expected query-param free "men")

it was possible to fix this by adding another regex to the pipeline but
it's cleaner to just use route.value.path as that's the intention of the implementation

M2-1035