### PR TITLE
ci: align release branch name convention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
       - develop
-      - release-**
+      - release/*
   pull_request:
     branches:
       - main
       - develop
-      - release-**
+      - release/*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
before this pr, pr checks for branches wanting to merge into release/someversionhere wouldn't run