### PR TITLE
ci: refactor k6 action to add new env vars

### DIFF
--- a/.github/workflows/deploy-vue-storefront-cloud.yml
+++ b/.github/workflows/deploy-vue-storefront-cloud.yml
@@ -17,47 +17,43 @@ jobs:
       deployment_id: ${{ steps.deployment.outputs.deployment_id }}
     steps:
       - name: Determine environment-specific variables
-        id: determine-environment
         shell: bash
         run: |
           REF=${{ github.ref }}
 
           if [ $REF = 'refs/heads/main' ]; then
-            ENVNAME='production'
-            ENVCODE='demo-magento2'
-            MIDDLEWARE_URL='https://demo-magento2.europe-west1.gcp.vuestorefront.cloud/api/'
+            ENVINFO_FILE=production
 
           elif [ $REF = 'refs/heads/develop' ]; then
-            ENVNAME='dev'
-            ENVCODE='demo-magento2-dev'
-            MIDDLEWARE_URL='https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io/api/'
+            ENVINFO_FILE=dev
 
           elif [[ $REF = refs/heads/release* ]]; then
-            ENVNAME='canary'
-            ENVCODE='demo-magento2-canary'
-            MIDDLEWARE_URL='https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io/api/'
+            ENVINFO_FILE=canary
 
           elif [ $REF = 'refs/heads/enterprise' ]; then
-            ENVNAME='enterprise'
-            ENVCODE='demo-magento2-enterprise'
-            MIDDLEWARE_URL='https://demo-magento2-enterprise.europe-west1.gcp.storefrontcloud.io/api/'
+            ENVINFO_FILE=enterprise
 
           else
-              echo 'unrecognized branch name'
-              exit 1
+            echo 'unrecognized branch name'
+            exit 1
           fi
 
-          echo ::set-output name=name::$ENVNAME
-          echo ::set-output name=code::$ENVCODE
-          echo ::set-output name=middleware-url::$MIDDLEWARE_URL
+          cat .github/workflows/public_env_info/$ENVINFO_FILE >> $GITHUB_ENV
+
+      - id: determine-environment
+        run: |
+          echo ::set-output name=name::${{ env.ENVNAME }}
+          echo ::set-output name=code::${{ env.ENVCODE }}
+          echo ::set-output name=middleware-url::${{ env.MIDDLEWARE_URL }}
 
       - name: Create GitHub deployment
         id: deployment
         uses: chrnorm/deployment-action@v2
         with:
           token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
-          environment: ${{ steps.determine-environment.outputs.name }}
+          environment: ${{ env.ENVNAME }}
           initial-status: in_progress
+
   build:
     needs: create-deployment
     runs-on: ubuntu-latest

--- a/.github/workflows/public_env_info/canary
+++ b/.github/workflows/public_env_info/canary
@@ -1,0 +1,5 @@
+ENVNAME=canary
+ENVCODE=demo-magento2-canary
+BASE_URL=https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io
+MIDDLEWARE_URL=https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io/api
+MAGENTO_GRAPHQL_URL=https://magento2-instance.vuestorefront.io:8443/graphql

--- a/.github/workflows/public_env_info/dev
+++ b/.github/workflows/public_env_info/dev
@@ -1,0 +1,5 @@
+ENVNAME=dev
+ENVCODE=demo-magento2-dev
+BASE_URL=https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io
+MIDDLEWARE_URL=https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io/api
+MAGENTO_GRAPHQL_URL=https://magento2-instance.vuestorefront.io:8443/graphql

--- a/.github/workflows/public_env_info/enterprise
+++ b/.github/workflows/public_env_info/enterprise
@@ -1,0 +1,5 @@
+ENVNAME=enterprise
+ENVCODE=demo-magento2-enterprise
+BASE_URL=https://demo-magento2-enterprise.europe-west1.gcp.storefrontcloud.io
+MIDDLEWARE_URL=https://demo-magento2-enterprise.europe-west1.gcp.storefrontcloud.io/api
+MAGENTO_GRAPHQL_URL=https://magento2-instance.vuestorefront.io:8443/graphql

--- a/.github/workflows/public_env_info/production
+++ b/.github/workflows/public_env_info/production
@@ -1,0 +1,5 @@
+ENVNAME=production
+ENVCODE=demo-magento2
+BASE_URL=https://demo-magento2.europe-west1.gcp.vuestorefront.cloud
+MIDDLEWARE_URL=https://demo-magento2.europe-west1.gcp.vuestorefront.cloud/api
+MAGENTO_GRAPHQL_URL=https://magento2-instance.vuestorefront.io:8443/graphql

--- a/.github/workflows/run-k6-load-test.yml
+++ b/.github/workflows/run-k6-load-test.yml
@@ -17,13 +17,8 @@ on:
       environment:
         description: The full URL of the environment on which load tests will be ran
         required: true
-        default: 'https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io'
-        type: choice
-        options:
-          - 'https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io'
-          - 'https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io'
-          - 'https://demo-magento2.europe-west1.gcp.storefrontcloud.cloud'
-          - 'https://demo-magento2-enterprise.europe-west1.gcp.storefrontcloud.io'
+        default: canary
+        type: environment
 
       flags:
         description: Additional argument and flags to provide to the k6 CLI. See https://k6.io/docs/using-k6/options for details.
@@ -40,10 +35,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Run k6 cloud test
+      - run: |
+          cat .github/workflows/public_env_info/${{ inputs.environment }} >> $GITHUB_ENV
+
+      - name: Run k6 test
         uses: grafana/k6-action@v0.2.0
         with:
           cloud: ${{ github.event.inputs.cloud }}
           token: ${{ secrets.K6_CLOUD_API_TOKEN }}
           filename: ${{ github.event.inputs.filename }}
-          flags: -e BASE_URL=${{ github.event.inputs.environment }} ${{ github.event.inputs.flags }}
+          flags: -e BASE_URL=${{ env.BASE_URL }} -e MIDDLEWARE_URL=${{ env.MIDDLEWARE_URL }} -e MAGENTO_GRAPHQL_URL=${{ env.MAGENTO_GRAPHQL_URL }} ${{ github.event.inputs.flags }}


### PR DESCRIPTION
Change K6 action so that it works by picking the environment rather than specifying the url. Our upcoming implementation of load tests will have three separate urls (magento instance, middleware url, frontend url). Specifying each url by hand/adding it to the url dropdown would be annoying