### PR TITLE
ci: stop using personal access token for deployment api

### DIFF
--- a/.github/workflows/deploy-vue-storefront-cloud.yml
+++ b/.github/workflows/deploy-vue-storefront-cloud.yml
@@ -10,6 +10,10 @@ on:
 jobs:
   create-deployment:
     runs-on: ubuntu-latest
+
+    permissions:
+      deployments: write
+
     outputs:
       environment-name: ${{ steps.determine-environment.outputs.name }}
       environment-code: ${{ steps.determine-environment.outputs.code }}
@@ -55,7 +59,7 @@ jobs:
         id: deployment
         uses: chrnorm/deployment-action@v2
         with:
-          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ github.token }}
           environment: ${{ steps.determine-environment.outputs.name }}
           initial-status: in_progress
   build:
@@ -130,6 +134,10 @@ jobs:
 
   finalize-deployment:
     runs-on: ubuntu-latest
+
+    permissions:
+      deployments: write
+
     needs: [create-deployment, build, deploy]
     if: always()
     steps:
@@ -137,7 +145,7 @@ jobs:
         if: ${{ !(contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')) }}
         uses: chrnorm/deployment-status@v2
         with:
-          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ github.token }}
           deployment-id: ${{ needs.create-deployment.outputs.deployment_id }}
           state: success
 
@@ -145,6 +153,6 @@ jobs:
         if: ${{ contains(join(needs.*.result, ','), 'failure') || contains(join(needs.*.result, ','), 'cancelled')  }}
         uses: chrnorm/deployment-status@v2
         with:
-          token: ${{ secrets.DEPLOYMENT_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ github.token }}
           deployment-id: ${{ needs.create-deployment.outputs.deployment_id }}
           state: failure


### PR DESCRIPTION
our approach to reporting deployment status changed so we no longer need
the personal access token workaround. In the past, it was needed because
the deploy-template.yml workflow was called by the parent
deploy-vue-storefront-cloud workflow, which is prevented by:
https://github.com/chrnorm/deployment-action/tree/3afecce166a0a2f92d3a9e7351a9908a72121c24#notes

using a personal access token is also not secure since if stolen it
could be used to push to the deployment status of every repo I have
access to (including vsf org).