### PR TITLE
feat: add i18n base url configuration

### DIFF
--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -135,6 +135,7 @@ export default () => {
     ],
     i18n: {
       country: 'US',
+      baseUrl: process.env.VSF_STORE_URL,
       strategy: 'prefix',
       locales: [
         {


### PR DESCRIPTION
## Description
i18n is responsible for basic SEO optimization including canonical URLs, it can be configured manually but I added VSF_STORE_ENV as a base URL which will be a good OOB solution for most projects.


## Motivation and Context
Improvement

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
