### PR TITLE
fix: header navigation "hasChildren" always returning true

### DIFF
--- a/packages/theme/components/Header/Navigation/HeaderNavigation.vue
+++ b/packages/theme/components/Header/Navigation/HeaderNavigation.vue
@@ -67,7 +67,7 @@ export default defineComponent({
       currentCategory.value = category;
     };
 
-    const hasChildren = (category: CategoryTree) => Boolean(category?.children);
+    const hasChildren = (category: CategoryTree) => Boolean(category?.children?.length);
 
     const setFocus = (event: MouseEvent & { target: HTMLElement }) => {
       focusedElement = event.target;


### PR DESCRIPTION
Description
If the value passed to Boolean is an empty array it will always return true.

Related Issue
https://github.com/vuestorefront/magento2/issues/1207

Types of changes
[x ] Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to change)
Checklist:
[ x] My code follows the code style of this project.
