### PR TITLE
fix: m2-938 fix issue with a store switching on the customer account

### DIFF
--- a/packages/theme/modules/customer/pages/MyAccount/AddressesDetails/AddressForm.vue
+++ b/packages/theme/modules/customer/pages/MyAccount/AddressesDetails/AddressForm.vue
@@ -290,10 +290,7 @@ export default defineComponent({
 
     const updateCountry = async (params: UseCountrySearchParams) => {
       country.value = await searchCountry(params);
-      form.value.region = {
-        // let region SfSelect know it should display initial state
-        ...(regionInformation.value.length > 0 ? { region_id: null } : {}),
-      };
+      form.value.region = { region_id: null, region_code: '' };
     };
 
     watch(() => props.address, () => {
@@ -318,9 +315,13 @@ export default defineComponent({
 
     const submitForm = () => {
       const regionId = regionInformation.value.find((r) => r.abbreviation === form.value.region.region_code)?.id;
-      if (regionId) {
-        form.value.region.region_id = regionId;
-      }
+      form.value.region = regionId
+        ? { region_id: regionId }
+        : {
+          ...form.value.region,
+          region_code: '',
+          region_id: null,
+        };
 
       emit('submit', {
         form: omitDeep(form.value, ['__typename']),


### PR DESCRIPTION
## Description
User cannot edit the address after switching from a country with state/province to non-state/province country 

## Related Issue
#1343 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Login.
2. Go to My Account.
3. Visit Address Details.
4. Add new address in country with provinces/states.
5. Save the address.
6. Hit Change button.
7. Change country to one without provinces/states in the dropdown i. e. Malta.
8. Save the address.
9. Open it one more time and try to edit some field or setup this address as a default for shipping or billing.
10. Save.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
