### PR TITLE
fix: m2-941 product is not marked as added to the wishlist

### DIFF
--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -186,6 +186,7 @@ export default defineComponent({
       isFilterSidebarOpen,
     } = useUiState();
     const {
+      load: loadWishlist,
       addItem: addItemToWishlistBase,
       isInWishlist,
       removeItem: removeItemFromWishlist,
@@ -237,6 +238,7 @@ export default defineComponent({
 
     const isPriceLoaded = ref(false);
     onMounted(async () => {
+      loadWishlist();
       const { getPricesBySku } = usePrice();
       if (products.value.length > 0) {
         const skus = products.value.map((item) => item.sku);

--- a/packages/theme/modules/catalog/pages/product.vue
+++ b/packages/theme/modules/catalog/pages/product.vue
@@ -46,8 +46,8 @@ import { useProduct } from '~/modules/catalog/product/composables/useProduct';
 import { getMetaInfo } from '~/helpers/getMetaInfo';
 import { usePageStore } from '~/stores/page';
 import { ProductTypeEnum } from '~/modules/catalog/product/enums/ProductTypeEnum';
+import { useWishlist, useApi } from '~/composables';
 import LoadWhenVisible from '~/components/utils/LoadWhenVisible.vue';
-import { useApi } from '~/composables';
 import type { Product } from '~/modules/catalog/product/types';
 import type { ProductDetailsQuery } from '~/modules/GraphQL/types';
 import ProductSkeleton from '~/modules/catalog/product/components/ProductSkeleton.vue';
@@ -79,7 +79,7 @@ export default defineComponent({
     const route = useRoute();
     const { getProductDetails, loading } = useProduct();
     const { error: nuxtError } = useContext();
-
+    const { load: loadWishlist } = useWishlist();
     const breadcrumbs = computed(() => {
       const productCategories = product.value?.categories ?? [];
       return getBreadcrumbs(
@@ -139,7 +139,9 @@ export default defineComponent({
       addTags([...tags, ...productTags]);
     });
 
-    onMounted(async () => fetchProductExtendedData());
+    onMounted(async () => {
+      await Promise.all([fetchProductExtendedData(), loadWishlist()]);
+    });
 
     return {
       renderer,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Before this PR product was not marked as added to the wishlist on the PDP and PLP. Now wishlist will be loaded on both pages to fetch the data required for evaluation if the product is added to the wishlist. 

## Motivation and Context
bugfix

## How Has This Been Tested?
1. Login.
2. Open the product detail page.
3. Move the mouse on "Add to wishlist" and click it.
4. Refresh the page.
5. Go back to the product list page where the product is displayed.
6. Move mouse on product preview of product added to wishlist.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
