### PR TITLE
docs: fixed breaking change reference link

### DIFF
--- a/docs/migration-guides/1.0.0/index.md
+++ b/docs/migration-guides/1.0.0/index.md
@@ -2,7 +2,7 @@
 
 Vue Storefront for Magento 1.0.0 contains backward-incompatible changes. To review these backward-incompatible changes, see
 
-[1.0.0 **Backward incompatible changes reference**](./1.0.0-bic)
+[1.0.0 **Backward incompatible changes reference**](./1.0.0-bic.md)
 
 ## Vue Storefront for Magento 1.0.0 highlights
 


### PR DESCRIPTION
Fixed wrong link to the BIC document
![Screenshot 2022-08-31 at 14 54 13](https://user-images.githubusercontent.com/11998249/187683032-ff40c80c-4b93-480c-a1c3-4ef30d84b8fa.png)


