### PR TITLE
fix: m2-930 product list page is sometimes unresponsive after the store switch

### DIFF
--- a/packages/theme/modules/catalog/pages/category.vue
+++ b/packages/theme/modules/catalog/pages/category.vue
@@ -207,7 +207,7 @@ export default defineComponent({
 
     const { fetch } = useFetch(async () => {
       if (!activeCategory.value) {
-        loadCategoryTree();
+        await loadCategoryTree();
       }
 
       const categoryUid = routeData.uid;


### PR DESCRIPTION
## Description
Product List Page, Product Detail Page - App is unresponsive after hard refreshing the page as a logged in user

## How Has This Been Tested?
Open any Product List Page.
2. Change store to "German".
3. Change currency to "PLN" or "EUR".
4. Switch store to default one.
5. Refresh the page.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
