### PR TITLE
fix!: displaying proper price and currency in the customer dashboard

### DIFF
--- a/packages/api-client/src/api/customerOrders/customerOrders.ts
+++ b/packages/api-client/src/api/customerOrders/customerOrders.ts
@@ -8,7 +8,6 @@ export default gql`
           number
           id
           order_date
-          grand_total
           total {
             discounts {
               amount {
@@ -16,6 +15,10 @@ export default gql`
                 value
               }
               label
+            }
+            grand_total {
+              currency
+              value
             }
             base_grand_total {
               currency

--- a/packages/theme/modules/checkout/getters/orderGetters.ts
+++ b/packages/theme/modules/checkout/getters/orderGetters.ts
@@ -2,9 +2,9 @@ import type { Pagination } from '~/composables/types';
 import type { CustomerOrders, CustomerOrder, OrderItemInterface } from '~/modules/GraphQL/types';
 
 export const getDate = (order: CustomerOrder): string => new Date(order?.order_date?.replace(/ /g, 'T')).toLocaleDateString();
-
-export const getPrice = (order: CustomerOrder): number => order?.total?.base_grand_total?.value ?? 0;
-
+export const getBaseGrandTotal = (order: CustomerOrder): number => order?.total?.base_grand_total?.value ?? 0;
+export const getGrandTotal = (order: CustomerOrder): number => order?.total?.grand_total.value ?? 0;
+export const getOrderCurrency = (order: CustomerOrder): string => order?.total?.subtotal.currency ?? 'USD';
 export const getItemPrice = (item: OrderItemInterface): number => item?.product_sale_price?.value ?? 0;
 
 const getPagination = (orders: CustomerOrders): Pagination => ({
@@ -17,7 +17,9 @@ const getPagination = (orders: CustomerOrders): Pagination => ({
 
 const orderGetters = {
   getDate,
-  getPrice,
+  getBaseGrandTotal,
+  getGrandTotal,
+  getOrderCurrency,
   getItemPrice,
   getPagination,
 };

--- a/packages/theme/modules/customer/pages/MyAccount/OrderHistory/OrderHistory.vue
+++ b/packages/theme/modules/customer/pages/MyAccount/OrderHistory/OrderHistory.vue
@@ -45,7 +45,7 @@
           >
             <SfTableData>{{ order.number }}</SfTableData>
             <SfTableData>{{ getDate(order) }}</SfTableData>
-            <SfTableData>{{ $fc(getPrice(order)) }}</SfTableData>
+            <SfTableData>{{ $fc(getGrandTotal(order), '', {currency: getOrderCurrency(order)}) }}</SfTableData>
             <SfTableData>
               <span :class="getStatusTextClass(order)">{{ order.status }}</span>
             </SfTableData>
@@ -173,7 +173,8 @@ export default defineComponent({
       getStatusTextClass,
       orderGetters,
       getDate: orderGetters.getDate,
-      getPrice: orderGetters.getPrice,
+      getGrandTotal: orderGetters.getGrandTotal,
+      getOrderCurrency: orderGetters.getOrderCurrency,
       orders: computed(() => rawCustomerOrders.value?.items ?? []),
       rawCustomerOrders,
       pagination,

--- a/packages/theme/modules/customer/pages/MyAccount/OrderHistory/SingleOrder/SingleOrder.vue
+++ b/packages/theme/modules/customer/pages/MyAccount/OrderHistory/SingleOrder/SingleOrder.vue
@@ -41,7 +41,7 @@
               </div>
             </SfTableData>
             <SfTableData>{{ item.quantity_ordered }}</SfTableData>
-            <SfTableData>{{ $fc(item.product_sale_price.value) }}</SfTableData>
+            <SfTableData>{{ $fc(item.product_sale_price.value, '', { currency: item.product_sale_price.currency }) }}</SfTableData>
           </SfTableRow>
 
           <OrderSummaryRow>
@@ -76,7 +76,7 @@
               {{ $t('Price') }}
             </template>
             <template #value>
-              {{ $fc(asyncData.order.total.base_grand_total.value) }}
+              {{ $fc(getGrandTotal(asyncData.order), '', {currency: getOrderCurrency(asyncData.order)}) }}
             </template>
           </OrderSummaryRow>
         </SfTable>
@@ -192,6 +192,8 @@ export default defineComponent({
       ordersRoute,
       asyncData,
       getDate: orderGetters.getDate,
+      getGrandTotal: orderGetters.getGrandTotal,
+      getOrderCurrency: orderGetters.getOrderCurrency,
     };
   },
 });

--- a/packages/theme/plugins/fcPlugin.ts
+++ b/packages/theme/plugins/fcPlugin.ts
@@ -20,7 +20,7 @@ declare module '@nuxt/types' {
 const plugin : Plugin = (context, inject) => {
   inject('fc', (value: number | string, locale?: string, options = {}): string => {
     // eslint-disable-next-line no-param-reassign
-    locale = locale || context.i18n?.localeProperties?.iso.replace('_', '-');
+    locale = (locale || context.i18n?.localeProperties?.iso || '').replace('_', '-');
     // eslint-disable-next-line no-param-reassign
     options = { currency: context.app.$vsf.$magento.config.state.getCurrency() || context.i18n?.localeProperties?.defaultCurrency, ...options };
     return formatCurrency(value, locale, options);


### PR DESCRIPTION
- rework deprecated grand_total from the customerOrders query
- make prices and currency constant in the customer dashboard

## Description
- [**Breaking Change**] To display the order's value properly it was necessary to get rid of the old base_price from the query because it was deprecated and use the current base price from the totals.
- There is no way to successfully switch currency for the order in the customer dashboard because rates are not saved once the order is placed. Therefore, we should always display the currency and the base price of the order when it was placed. As a result, orders placed in EUR will be always displayed in EUR without any rate calculations.


## Related Issue
#1342

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Given: user with orders in the German store.

1. log in to the German store.
2. Click "My account" icon in the top navbar.
3. Go to "Bestellverlauf".
4. Click the currency symbol at the top of the page.
5. Switch currency.
6. Open order details.
7. Click the currency symbol at the top of the page.
8. Switch currency.
9. Observe the order's currency and value remain the same as when the order was placed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
