### PR TITLE
fix: m2-1018 productdetails page images are not displayed on the brow…

### DIFF
--- a/packages/theme/modules/catalog/product/components/product-types/styles.scss
+++ b/packages/theme/modules/catalog/product/components/product-types/styles.scss
@@ -162,6 +162,9 @@
 }
 
 ::v-deep .sf-gallery__thumbs {
+  .sf-image {
+    position: relative;
+  }
   .sf-image-loaded {
     display: block;
   }


### PR DESCRIPTION
## Description
Before this PR thumbnails in the gallery in the mobile view were not displayed correctly when user was navigating in the browser.

## How Has This Been Tested?
Navigate to the PDP in the mobile view, and observe that the gallery images are now all loaded and displayed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
