### PR TITLE
feat: add a buildtime google font api probe mechanism

### DIFF
--- a/packages/theme/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
+++ b/packages/theme/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export const GOOGLE_FONT_API_URL = 'https://google-webfonts-helper.herokuapp.com/api/fonts';
+
+/**
+ * Check
+ */
+export const probeGoogleFontsApi = async () => {
+  try {
+    await axios.get(GOOGLE_FONT_API_URL);
+    return true;
+  } catch (err) {
+    console.warn('GoogleFontsAPI is unavailable:', err);
+  }
+
+  return false;
+};
+
+export default probeGoogleFontsApi;

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -4,6 +4,7 @@
 import webpack from 'webpack';
 import middleware from './middleware.config';
 import { getRoutes } from './routes';
+import { probeGoogleFontsApi, GOOGLE_FONT_API_URL } from './modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts';
 
 const GoogleFontsPlugin = require('@beyonk/google-fonts-webpack-plugin');
 
@@ -25,7 +26,7 @@ const {
   },
 } = middleware;
 
-export default () => {
+export default async () => {
   const baseConfig = {
     ssr: true,
     dev: process.env.VSF_NUXT_APP_ENV !== 'production',
@@ -206,18 +207,6 @@ export default () => {
             lastCommit: process.env.LAST_COMMIT || '',
           }),
         }),
-        new GoogleFontsPlugin({
-          fonts: [
-            { family: 'Raleway', variants: ['300', '400', '500', '600', '700', '400italic'], display: 'swap' },
-            { family: 'Roboto', variants: ['300', '400', '500', '700', '300italic', '400italic'], display: 'swap' },
-          ],
-          name: 'fonts',
-          filename: 'fonts.css',
-          path: 'assets/fonts/',
-          local: true,
-          formats: ['eot', 'woff', 'woff2', 'ttf', 'svg'],
-          apiUrl: 'https://google-webfonts-helper.herokuapp.com/api/fonts',
-        }),
       ],
       transpile: [
         'vee-validate',
@@ -292,6 +281,21 @@ export default () => {
       ...baseConfig.publicRuntimeConfig,
       isRecaptcha: process.env.VSF_RECAPTCHA_ENABLED === 'true',
     };
+  }
+
+  if (await probeGoogleFontsApi()) {
+    baseConfig.build.plugins.push(new GoogleFontsPlugin({
+      fonts: [
+        { family: 'Raleway', variants: ['300', '400', '500', '600', '700', '400italic'], display: 'swap' },
+        { family: 'Roboto', variants: ['300', '400', '500', '700', '300italic', '400italic'], display: 'swap' },
+      ],
+      name: 'fonts',
+      filename: 'fonts.css',
+      path: 'assets/fonts/',
+      local: true,
+      formats: ['eot', 'woff', 'woff2', 'ttf', 'svg'],
+      apiUrl: GOOGLE_FONT_API_URL,
+    }));
   }
 
   return baseConfig;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
If **https://google-webfonts-helper.herokuapp.com/api** is not responsive, the plugin will be omitted and appropriate information will be logged in the console. Before this PR, if the GoogleFontAPI, Heroku CDN, or any intermediate service were down, the app could not build properly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
