### PR TITLE
fix: getMagentoImage reading 'split' error

### DIFF
--- a/packages/theme/composables/useImage/index.ts
+++ b/packages/theme/composables/useImage/index.ts
@@ -36,11 +36,13 @@ export function useImage(): UseImageInterface {
   /**
    * Extract image path from Magento URL.
    *
-   * @param fullImageUrl {string}
+   * @param fullImageUrl {string | null}
    *
    * @return {string}
    */
-  const getMagentoImage = (fullImageUrl: string) => {
+  const getMagentoImage = (fullImageUrl: string | null) => {
+    if (!fullImageUrl) return '';
+
     // @ts-ignore
     const { imageProvider, magentoBaseUrl } = context.$vsf.$magento.config;
 


### PR DESCRIPTION
## Description
Fix that will resolve the following error.

```
ERROR Cannot read properties of null (reading 'split')
 at a.getMagentoImage (composables/useImage/index.ts:48:31)
 at 65.js:6481:379
 at a.ve [as _l] (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:15953)
 at a.GroupedProductSelectorvue_type_template_id_59640822_render (modules/catalog/product/components/product-types/grouped/GroupedProductSelector.vue)
 at /var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13873
 at qt (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13228)
 at a.r.render (/var/www/node_modules/@vue/composition-api/dist/vue-composition-api.common.prod.js:16:13844)
 at a.t._render (/var/www/node_modules/vue/dist/vue.runtime.common.prod.js:6:35346)
 at /var/www/node_modules/vue-server-renderer/build.prod.js:1:70854
 at eo (/var/www/node_modules/vue-server-renderer/build.prod.js:1:67418)
```

## How Has This Been Tested?
The issue occurred from time to time but basically, move around galleries on the PDP and PLP to eventually get the error.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
