### PR TITLE
fix: cart type error in the console after opening mini cart as a guest

### DIFF
--- a/packages/theme/components/CartSidebar.vue
+++ b/packages/theme/components/CartSidebar.vue
@@ -361,7 +361,7 @@ export default defineComponent({
     const tempProduct = ref();
 
     onMounted(() => {
-      if (!cart.value.id) {
+      if (!cart.value?.id) {
         loadCart();
       }
     });


### PR DESCRIPTION
## Description
Fix the issue: 

1. Visit M2 integration app as a guest.
2. Click cart icon in top navigation.

```
Following error occurs in the console:
`TypeError: Cannot read properties of null (reading 'id')
    at CartSidebar.vue?b5dd:364:23
    at f.<anonymous> (vue-composition-api.mjs:1125:23)
    at ee (vue.runtime.esm.js:1863:57)
    at vn (vue.runtime.esm.js:4235:7)
    at Object.insert (vue.runtime.esm.js:3158:7)
    at j (vue.runtime.esm.js:6390:28)
    at f.__patch__ (vue.runtime.esm.js:6609:5)
    at t._update (vue.runtime.esm.js:3963:19)
    at f.r (vue.runtime.esm.js:4081:10)
    at En.get (vue.runtime.esm.js:4495:25)
```

## How Has This Been Tested?
I was no longer able to reproduce the issue following the steps in the description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
