### PR TITLE
fix: product detail gallery is missing when browsing products using mobile

### DIFF
--- a/packages/theme/modules/catalog/product/components/product-types/styles.scss
+++ b/packages/theme/modules/catalog/product/components/product-types/styles.scss
@@ -162,6 +162,9 @@
 }
 
 ::v-deep .sf-gallery__thumbs {
+  .sf-image {
+    position: relative;
+  }
   .sf-image-loaded {
     display: block;
   }


### PR DESCRIPTION
## Description
The product detail gallery is missing when browsing products using mobile chromium-based browsers

## How Has This Been Tested?
1. Visit M2 integration app using chromium based mobile browser (Chrome or Samsung Internet).
2. Go to any product with image gallery, e. g. https://magento2stage.vuestorefront.io/default/erika-running-short.html
3. Observe that the gallery is now visible

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
