### PR TITLE
fix: ssr reload on the grouped product page

### DIFF
--- a/packages/api-client/src/api/productDetail/productDetailsQuery.ts
+++ b/packages/api-client/src/api/productDetail/productDetailsQuery.ts
@@ -131,8 +131,42 @@ export default gql`
         }
         ... on GroupedProduct {
           items {
+            position
+            qty
             product {
+              uid
               sku
+              name
+              stock_status
+              only_x_left_in_stock
+              price_range {
+                maximum_price {
+                  final_price {
+                    currency
+                    value
+                  }
+                  regular_price {
+                    currency
+                    value
+                  }
+                }
+                minimum_price {
+                  final_price {
+                    currency
+                    value
+                  }
+                  regular_price {
+                    currency
+                    value
+                  }
+                }
+              }
+              thumbnail {
+                url
+                position
+                disabled
+                label
+              }
             }
           }
         }

--- a/packages/theme/lang/de.js
+++ b/packages/theme/lang/de.js
@@ -306,4 +306,5 @@ export default {
   "The user password was changed successfully updated!":"Das Benutzerpasswort wurde erfolgreich geändert aktualisiert!",
   "The user account data was successfully updated!":"Die Benutzerkontodaten wurden erfolgreich aktualisiert!",
   "You submitted your review for moderation.": "Sie haben Ihre Bewertung zur Moderation eingereicht.",
+  "Starting at": "Beginnt um",
 };

--- a/packages/theme/lang/en.js
+++ b/packages/theme/lang/en.js
@@ -304,4 +304,5 @@ export default {
   "The user password was changed successfully updated!":"The user password was changed successfully updated!",
   "The user account data was successfully updated!":"The user account data was successfully updated!",
   "You submitted your review for moderation.": "You submitted your review for moderation.",
+  "Starting at": "Starting at",
 };

--- a/packages/theme/modules/catalog/product/components/product-types/grouped/GroupedProductSelector.vue
+++ b/packages/theme/modules/catalog/product/components/product-types/grouped/GroupedProductSelector.vue
@@ -40,7 +40,7 @@
       class="color-primary sf-button grouped_items--add-to-cart"
       @click="addToCart"
     >
-      {{ $t('Add to Cart') }}
+      {{ $t('Add to cart') }}
     </SfButton>
     <SfAlert
       :style="{ visibility: !!addToCartError ? 'visible' : 'hidden'}"


### PR DESCRIPTION
## Description
Product Detail Page - 500 after refreshing the product detail page of the grouped product

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Visit M2's integration page - DEV.
2. Go to "Gear".
3. Open PDP of "Set of Sprite Yoga Straps".
4. Refresh the page.
5. Observe that the product is loaded properly

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
