### PR TITLE
docs: removed outdated information about cors configuration

### DIFF
--- a/docs/installation-setup/configure-magento.md
+++ b/docs/installation-setup/configure-magento.md
@@ -84,45 +84,7 @@ Then go to the admin panel, find the configuration panel of the `GraphQL CustomC
 
 For more information, see the [GraphQL security configuration](https://devdocs.magento.com/guides/v2.4/graphql/security-configuration.html) page.
 
-### 5. Enable CORS
-
-You may need to enable CORS origins in your Magento store to accept requests from other domains, e.g., `magento.dev`. In the Magento 2 folder, add the package `graycore/magento2-cors` by running the command below:
-
-```sh
-bin/composer require graycore/magento2-cors
-```
-
-Then, add the following configuration at the end of `src/app/etc/env.php`:
-
-```php
-    'system' => [
-        'default' => [
-            'web' => [
-                'graphql' => [
-                    'cors_max_age' => 86400,
-                    'cors_allow_credentials' => 0,
-                    'cors_allowed_methods' => 'POST, OPTIONS, GET',
-                    'cors_allowed_headers' => 'Content-Currency, Store, X-Magento-Cache-Id, X-Captcha, Content-Type, Authorization, DNT, TE',
-                    'cors_allowed_origins' => '*'
-                ]
-            ]
-        ]
-    ]
-```
-
-Enable the graycore cors.
-
-```sh
-bin/magento module:enable Graycore_Cors
-```
-
-Then update the configuration:
-
-```sh
-bin/magento setup:upgrade
-```
-
-### 6. Populate store with sample data (optional)
+### 5. Populate store with sample data (optional)
 
 In the Magento 2 folder, execute the commands below to add sample data to your store.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Once we remove graphql-request and do not send requests to Magento directly from the front end, we can remove information about CORS configuration from the installation guide.

## Motivation and Context
Keep docs up to date

## How Has This Been Tested?
I tested docs on my local

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
