### PR TITLE
fix: remove `stock_status` and `only_x_left_in_stock` fields from `productDetailsQuery`

### DIFF
--- a/packages/api-client/src/api/productDetail/productDetailsQuery.ts
+++ b/packages/api-client/src/api/productDetail/productDetailsQuery.ts
@@ -17,8 +17,6 @@ export default gql`
         uid
         sku
         name
-        stock_status
-        only_x_left_in_stock
         thumbnail {
           url
           position


### PR DESCRIPTION
## Description
Remove `stock_status` and `only_x_left_in_stock` fields from `productDetailsQuery`.

## Related Issue
This PR is related to #834.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
