### PR TITLE
docs: fix demo links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,9 @@ If you want to see the integration in action, we have three demo environments wh
 
 In the production environment, you can see the latest **released and stable** version of the integration. It should be visually and feature-wise identical to the new project installed using our CLI. 
 
-::: warning Please use this environment to replicate or validate any issue in the integration. :::
+::: warning 
+Please use this environment to replicate or validate any issue in the integration. 
+:::
 
 [Production demo](https://demo-magento2.europe-west1.gcp.vuestorefront.cloud)
 
@@ -27,7 +29,9 @@ In the production environment, you can see the latest **released and stable** ve
 
 In the staging environment, we are testing new releases. It should be **relatively stable**, but you might still encounter some bugs.
 
-::: warning Don't use this environment to check for errors and isseus, as this is the final development pipeline environment. :::
+::: warning 
+Don't use this environment to check for errors and issues, as this is the final development pipeline environment. 
+:::
 
 [Staging demo](https://demo-magento2-canary.europe-west1.gcp.storefrontcloud.io)
 
@@ -35,6 +39,8 @@ In the staging environment, we are testing new releases. It should be **relative
 
 In the development environment, we are testing the `develop` branch, which might contain unfinished or experimental features. It might be **unstable** both visually and feature-wise.
 
-::: warning Don't use this environment to check for errors and isseus. The code deployed are very fresh and can contain bugs and errors. :::
+::: warning 
+Don't use this environment to check for errors and issues. The code deployed are very fresh and can contain bugs and errors. 
+:::
 
 [Development environment](https://demo-magento2-dev.europe-west1.gcp.storefrontcloud.io)


### PR DESCRIPTION
Fixes demo links formatting. It appears this issue might have been caused by Prettier in someone's local dev env?

## Description
- fix formatting on `docs/index.md` (the home page)
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/18535681/202732203-206ed0b9-fa12-4c0e-9332-ec1b6ceef9db.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
