### PR TITLE
fix: google fonts api plugin

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "dev": "vuepress dev",
     "build": "vuepress build --max-concurrency=32",
-    "api-extract": "cd ../ && yarn build && cd docs/ && yarn api-ref && yarn theme-ref && yarn ref-md",
+    "api-extract": "cd ../ && yarn build && cd docs/ && yarn api-ref && yarn ref-md",
     "api-ref": "cd ../packages/api-client && api-extractor run --local",
     "theme-ref": "cd ../scripts && node generateApiReference.mjs",
     "ref-md": "api-documenter markdown --i api-reference --o api-reference"

--- a/packages/theme/modules/core/GoogleFontsAPI/__tests__/probeGoogleFontsApi.spec.ts
+++ b/packages/theme/modules/core/GoogleFontsAPI/__tests__/probeGoogleFontsApi.spec.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+import probeGoogleFontsApi from '~/modules/core/GoogleFontsAPI/probeGoogleFontsApi';
+
+jest.mock('axios');
+const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation();
+
+describe('[probeGoogleFontsApi]', () => {
+  it('if service is available returns true', async () => {
+    (axios.get as jest.Mock).mockImplementation(() => Promise.resolve({ data: 'some_data' }));
+
+    const result = await probeGoogleFontsApi();
+
+    expect(result).toEqual(true);
+  });
+
+  it('if service is unavailable returns false', async () => {
+    const err = new Error('error');
+    (axios.get as jest.Mock).mockImplementation(() => Promise.reject(err));
+
+    const result = await probeGoogleFontsApi();
+
+    expect(result).toEqual(false);
+    expect(consoleWarnMock).toBeCalledTimes(1);
+    expect(consoleWarnMock).toBeCalledWith('GoogleFontsAPI is unavailable:', err);
+  });
+});

--- a/packages/theme/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
+++ b/packages/theme/modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export const GOOGLE_FONT_API_URL = 'https://https://gwfh.mranftl.com/api/fonts';
+
+/**
+ * Check
+ */
+export const probeGoogleFontsApi = async () => {
+  try {
+    await axios.get(GOOGLE_FONT_API_URL);
+    return true;
+  } catch (err) {
+    console.warn('GoogleFontsAPI is unavailable:', err);
+  }
+
+  return false;
+};
+
+export default probeGoogleFontsApi;

--- a/packages/theme/nuxt.config.js
+++ b/packages/theme/nuxt.config.js
@@ -4,6 +4,7 @@
 import webpack from 'webpack';
 import middleware from './middleware.config';
 import { getRoutes } from './routes';
+import { probeGoogleFontsApi, GOOGLE_FONT_API_URL } from './modules/core/GoogleFontsAPI/probeGoogleFontsApi.ts';
 
 const GoogleFontsPlugin = require('@beyonk/google-fonts-webpack-plugin');
 
@@ -25,7 +26,7 @@ const {
   },
 } = middleware;
 
-export default () => {
+export default async () => {
   const baseConfig = {
     ssr: true,
     dev: process.env.VSF_NUXT_APP_ENV !== 'production',
@@ -206,18 +207,6 @@ export default () => {
             lastCommit: process.env.LAST_COMMIT || '',
           }),
         }),
-        new GoogleFontsPlugin({
-          fonts: [
-            { family: 'Raleway', variants: ['300', '400', '500', '600', '700', '400italic'], display: 'swap' },
-            { family: 'Roboto', variants: ['300', '400', '500', '700', '300italic', '400italic'], display: 'swap' },
-          ],
-          name: 'fonts',
-          filename: 'fonts.css',
-          path: 'assets/fonts/',
-          local: true,
-          formats: ['eot', 'woff', 'woff2', 'ttf', 'svg'],
-          apiUrl: 'https://google-webfonts-helper.herokuapp.com/api/fonts',
-        }),
       ],
       transpile: [
         'vee-validate',
@@ -292,6 +281,22 @@ export default () => {
       ...baseConfig.publicRuntimeConfig,
       isRecaptcha: process.env.VSF_RECAPTCHA_ENABLED === 'true',
     };
+  }
+
+  if (await probeGoogleFontsApi()) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    baseConfig.build.plugins.push(new GoogleFontsPlugin({
+      fonts: [
+        { family: 'Raleway', variants: ['300', '400', '500', '600', '700', '400italic'], display: 'swap' },
+        { family: 'Roboto', variants: ['300', '400', '500', '700', '300italic', '400italic'], display: 'swap' },
+      ],
+      name: 'fonts',
+      filename: 'fonts.css',
+      path: 'assets/fonts/',
+      local: true,
+      formats: ['eot', 'woff', 'woff2', 'ttf', 'svg'],
+      apiUrl: GOOGLE_FONT_API_URL,
+    }));
   }
 
   return baseConfig;


### PR DESCRIPTION
- update google font api url
- add probe to check if the service is available<!--- Provide a general summary of your changes in the Title above -->

## Description
The current document building and deployment was requesting the usage of the API-Reference for the `theme` package. 

And that was creating almost 3000+ `.md` files for VuePress to manage and create specific routings.

With this change, only the API will be deployed as API-reference.

As shown by @mattmaribojoc 
![image](https://user-images.githubusercontent.com/1626923/205554406-a1aea153-7b30-4719-81e8-aae8fcd0f3ab.png)

The API-Reference counts as 3% of our documentation traffic, and this usage of GitHub actions is not being well used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This PR requires the PR https://github.com/vuestorefront/magento2/pull/1397 to be merged.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Documentation was taking hours to build, and creating pages that are not even visited by our users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
