### PR TITLE
Ignore common URL parameters for paid advertising

### DIFF
--- a/packages/theme/composables/useUiHelpers/index.ts
+++ b/packages/theme/composables/useUiHelpers/index.ts
@@ -4,7 +4,7 @@ import type { UseUiHelpersInterface } from '~/composables';
 import type { Params, QueryParams, FilterParams } from './Params';
 import type { FacetInterface } from '~/modules/catalog/category/types';
 
-const nonFilters = new Set(['page', 'sort', 'term', 'itemsPerPage']);
+const nonFilters = new Set(['page', 'sort', 'term', 'itemsPerPage', 'gclid', 'fbclid']);
 
 function reduceFilters(query: QueryParams) {
   return (prev: FilterParams, curr: string): FilterParams => {


### PR DESCRIPTION
## Description
Url parameters such as `gclid` are common when using paid advertising, these currently cause category pages to 404 as the parameter gets passed to Magento as a search query.

## Motivation and Context
Prevents `gclid` and `fbclid` being passed on to Magento.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
