### PR TITLE
fix: products fetch http codes change

### DIFF
--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-storefront/magento-api",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "sideEffects": false,
   "homepage": "https://github.com/vuestorefront/magento2",
   "bugs": {

--- a/packages/api-client/src/api/productDetails/index.ts
+++ b/packages/api-client/src/api/productDetails/index.ts
@@ -61,17 +61,13 @@ export default async function productDetails(
     },
   });
   try {
-    const result = await context.client.query<ProductDetailsQuery, ProductDetailsQueryVariables>({
+    return await context.client.query<ProductDetailsQuery, ProductDetailsQueryVariables>({
       query: gql`${productDetailGQL.query}`,
       variables: productDetailGQL.variables,
       context: {
         headers: getHeaders(context, customHeaders),
       },
     });
-
-    if (result.data.products.items.length === 0) throw new Error('No products found');
-
-    return result;
   } catch (error) {
     // For error in data we don't throw 500, because it's not server error
     if (error.graphQLErrors) {

--- a/packages/api-client/src/api/products/index.ts
+++ b/packages/api-client/src/api/products/index.ts
@@ -62,17 +62,13 @@ export default async function products(
   });
 
   try {
-    const result = await context.client.query<ProductsListQuery, ProductsListQueryVariables>({
+    return await context.client.query<ProductsListQuery, ProductsListQueryVariables>({
       query: gql`${productsGQL.query}`,
       variables: productsGQL.variables,
       context: {
         headers: getHeaders(context, customHeaders),
       },
     });
-
-    if (result.data.products.items.length === 0) throw new Error('No products found');
-
-    return result;
   } catch (error) {
     // For error in data we don't throw 500, because it's not server error
     if (error.graphQLErrors) {


### PR DESCRIPTION
## Description
When a product is not found it results in a 500. This should result in a 404, or perhaps still a 200. But 500 is not correct in any case.

- refactor product fetch endpoints to return 200 instead of 500 when no products found

closing [IN-3282](https://vsf.atlassian.net/browse/IN-3282)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


[IN-3282]: https://vsf.atlassian.net/browse/IN-3282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ