### PR TITLE
fix: get available payment methods type

### DIFF
--- a/.changeset/clever-ducks-chew.md
+++ b/.changeset/clever-ducks-chew.md
@@ -1,0 +1,6 @@
+---
+"@vue-storefront/magento-types": patch
+---
+
+Fixes
+- Fixed `getAvailablePaymentMethods` type definition. Parameter `cartId` is now properly typed as `string`.

--- a/packages/api-types/src/Api.ts
+++ b/packages/api-types/src/Api.ts
@@ -348,7 +348,7 @@ export interface MagentoApiMethods {
   ): Promise<ApolloQueryResult<CustomerAvailableShippingMethodsQuery>>;
 
   getAvailablePaymentMethods(
-    params: { cartId: string },
+    cartId: string,
     customQuery?: CustomQuery,
     customHeaders?: CustomHeaders
   ): Promise<ApolloQueryResult<GuestAvailablePaymentMethodsQuery>>;


### PR DESCRIPTION
Error
[GraphQL error]: Message: Variable "$cartId" got invalid value {"cartId":""}; String cannot represent a non string value: {"cartId":""}, Location: [column: 36, line: 1], Path: undefined

How to reproduce:
Go through the checkout process. Once you get to the payment selection part of the process you will see that it freezes in the UI and you get the error in the console. 

### 🔗 Linked issue
closing [https://vsf.atlassian.net/browse/IN-3771](https://vsf.atlassian.net/browse/IN-3771)
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
