### PR TITLE
Fix magento-sdk package location

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ yarn add @vue-storefront/sdk @vue-storefront/magento-sdk
 
 ```ts
 import { buildModule, initSDK } from '@vue-storefront/sdk';
-import { magentoModule, MagentoModuleType } from '@vue-storefront/sdk/magento-sdk';
+import { magentoModule, MagentoModuleType } from '@vue-storefront/magento-sdk';
 
 const sdkConfig = {
   magento: buildModule<MagentoModuleType>(magentoModule, {


### PR DESCRIPTION
The docs say `@vue-storefront/sdk/magento-sdk` but it needs to be `@vue-storefront/magento-sdk` right?

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution guide before creating a pull request
 👉 https://github.com/vuestorefront/.github/blob/main/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSDoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
