### PR TITLE
chore: change context type to interface

### DIFF
--- a/.changeset/random-name-tg.md
+++ b/.changeset/random-name-tg.md
@@ -1,0 +1,5 @@
+---
+"@vsf-enterprise/magento-api": patch
+---
+
+[CHANGED] `Context` from type to interface to allow declaration merging.

--- a/.changeset/random-name-tg.md
+++ b/.changeset/random-name-tg.md
@@ -1,5 +1,5 @@
 ---
-"@vsf-enterprise/magento-api": patch
+"@vue-storefront/magento-api": patch
 ---
 
 [CHANGED] `Context` from type to interface to allow declaration merging.

--- a/packages/api-client/src/types/context.ts
+++ b/packages/api-client/src/types/context.ts
@@ -2,4 +2,4 @@ import { ApiClientMethods, IntegrationContext } from "@vue-storefront/middleware
 import { MagentoApiMethods } from "@vue-storefront/magento-types";
 import { ClientInstance, Config } from "./setup";
 
-export type Context = IntegrationContext<ClientInstance, Config, ApiClientMethods<MagentoApiMethods>>;
+export interface Context extends IntegrationContext<ClientInstance, Config, ApiClientMethods<MagentoApiMethods>> {};

--- a/packages/api-client/src/types/context.ts
+++ b/packages/api-client/src/types/context.ts
@@ -2,4 +2,5 @@ import { ApiClientMethods, IntegrationContext } from "@vue-storefront/middleware
 import { MagentoApiMethods } from "@vue-storefront/magento-types";
 import { ClientInstance, Config } from "./setup";
 
-export interface Context extends IntegrationContext<ClientInstance, Config, ApiClientMethods<MagentoApiMethods>> {};
+// eslint-disable-next-line @typescript-eslint/no-empty-interface -- Allow extending this interface
+export interface Context extends IntegrationContext<ClientInstance, Config, ApiClientMethods<MagentoApiMethods>> {}


### PR DESCRIPTION
In extensions in `beforeCall` hook, we're able to override the `configuration`. However it's not possible to add typing for it. Having an IntegrationContext as interface would allow user to use the declaration merging.