### PR TITLE
chore: changeset

### DIFF
--- a/.changeset/wicked-baboons-run.md
+++ b/.changeset/wicked-baboons-run.md
@@ -1,0 +1,15 @@
+---
+"@vue-storefront/magento-api": major
+---
+
+- **[BREAKING]** Updated `@vue-storefront/middleware` version to `4.1.0`. Make sure this version is used in your project.
+
+```diff
+{
+  ...
+  "dependencies": {
+-   "@vue-storefront/middleware": "3.x.x",
++   "@vue-storefront/middleware": "4.1.0"
+  }
+}
+```


### PR DESCRIPTION
We need to deprecate the package released here #1538. That's because its changes are not really patch changes and are in fact breaking.

But before we deprecate those faulty releases, we need to release a proper major release. This PR does that.